### PR TITLE
Feat: Presigned URL 구현

### DIFF
--- a/.github/workflows/release-drafter-config.yml
+++ b/.github/workflows/release-drafter-config.yml
@@ -1,22 +1,25 @@
 name-template: 'v$RESOLVED_VERSION 🌈'
 tag-template: 'v$RESOLVED_VERSION'
-commitish: main
 # publish: true # 릴리즈를 자동으로 게시
+commitish: main
 categories:
-  - title: '🚀 Major Update'
-    labels:
-      - 'major'
   - title: '🚀 Features'
     labels:
       - 'enhancement'
   - title: '🐛 Bug Fixes'
     labels:
-      - 'fix'
       - 'bug'
   - title: '🧰 Maintenance'
-    label: 'chore'
-change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
-change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+    labels:
+      - 'chore'
+change-template: '- $TITLE ([#$NUMBER]($URL)) by @$AUTHOR'
+exclude-labels:
+  - 'skip-release-tag'
+include-labels:
+  - 'major'
+  - 'bug'
+  - 'enhancement'
+  - 'chore'
 version-resolver:
   major:
     labels:
@@ -26,12 +29,9 @@ version-resolver:
       - 'enhancement'
   patch:
     labels:
-      - 'fix'
       - 'bug'
       - 'chore'
   default: patch
 template: |
-  ## Changes
-
   $CHANGES
 

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,27 +1,16 @@
-name: draft-release
-
+name: Create Release Draft
 on:
-  pull_request:
+  push:
     branches:
       - main
-    types:
-      - closed
-
-
-permissions:
-  contents: read
 
 jobs:
-  update_release_draft:
-    if: github.event.pull_request.merged == true
-    permissions:
-      contents: write
-      pull-requests: write
+  create-draft:
     runs-on: ubuntu-latest
     steps:
       - name: Release
         uses: release-drafter/release-drafter@v6
         with:
-          config-name: /workflows/release-drafter-config.yml
+          config-name: release-drafter-config.yml
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/src/main/java/com/games/balancegameback/core/config/S3Config.java
+++ b/src/main/java/com/games/balancegameback/core/config/S3Config.java
@@ -6,6 +6,7 @@ import org.springframework.context.annotation.Configuration;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 @Configuration
@@ -23,6 +24,17 @@ public class S3Config {
     @Bean
     public S3Presigner s3Presigner() {
         return S3Presigner.builder()
+                .region(Region.AP_NORTHEAST_2)
+                .credentialsProvider(getCredentialsProvider())
+                .build();
+    }
+
+    /**
+     * S3Client 설정
+     */
+    @Bean
+    public S3Client s3Client() {
+        return S3Client.builder()
                 .region(Region.AP_NORTHEAST_2)
                 .credentialsProvider(getCredentialsProvider())
                 .build();

--- a/src/main/java/com/games/balancegameback/core/config/S3Config.java
+++ b/src/main/java/com/games/balancegameback/core/config/S3Config.java
@@ -6,7 +6,7 @@ import org.springframework.context.annotation.Configuration;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
-import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 @Configuration
 public class S3Config {
@@ -17,13 +17,19 @@ public class S3Config {
     @Value("${cloud.aws.credentials.secretKey}")
     private String secretKey;
 
+    /**
+     * S3Presigner 설정 (Presigned URL 생성용)
+     */
     @Bean
-    public S3Client defaultS3Client() {
-        AwsBasicCredentials awsCreds = AwsBasicCredentials.create(accessKey, secretKey);
-
-        return S3Client.builder()
+    public S3Presigner s3Presigner() {
+        return S3Presigner.builder()
                 .region(Region.AP_NORTHEAST_2)
-                .credentialsProvider(StaticCredentialsProvider.create(awsCreds))
+                .credentialsProvider(getCredentialsProvider())
                 .build();
+    }
+
+    private StaticCredentialsProvider getCredentialsProvider() {
+        AwsBasicCredentials awsCreds = AwsBasicCredentials.create(accessKey, secretKey);
+        return StaticCredentialsProvider.create(awsCreds);
     }
 }

--- a/src/main/java/com/games/balancegameback/core/jwt/JwtAuthenticationTokenFilter.java
+++ b/src/main/java/com/games/balancegameback/core/jwt/JwtAuthenticationTokenFilter.java
@@ -25,7 +25,7 @@ import java.util.Set;
 public class JwtAuthenticationTokenFilter extends OncePerRequestFilter {
 
     private static final Set<String> EXCLUDED_PATHS = Set.of(
-            "**/swagger", "**/v3/api-docs", "**/users/login", "**/users/signup"
+            "**/swagger", "**/v3/api-docs", "**/users/login", "**/users/signup, **/media/**"
     );
 
     private final JwtTokenProvider jwtTokenProvider;

--- a/src/main/java/com/games/balancegameback/dto/media/PresignedUrlRequest.java
+++ b/src/main/java/com/games/balancegameback/dto/media/PresignedUrlRequest.java
@@ -1,0 +1,16 @@
+package com.games.balancegameback.dto.media;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class PresignedUrlRequest {
+
+    @Schema(description = "닉네임")
+    private String prefix;
+
+    @Schema(description = "이메일")
+    private String fileName;
+}

--- a/src/main/java/com/games/balancegameback/dto/media/PresignedUrlRequest.java
+++ b/src/main/java/com/games/balancegameback/dto/media/PresignedUrlRequest.java
@@ -10,7 +10,4 @@ public class PresignedUrlRequest {
 
     @Schema(description = "prefix")
     private String prefix;
-
-    @Schema(description = "파일 이름")
-    private String fileName;
 }

--- a/src/main/java/com/games/balancegameback/dto/media/PresignedUrlsRequest.java
+++ b/src/main/java/com/games/balancegameback/dto/media/PresignedUrlsRequest.java
@@ -4,13 +4,16 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Data
 @NoArgsConstructor
-public class PresignedUrlRequest {
+public class PresignedUrlsRequest {
 
     @Schema(description = "prefix")
     private String prefix;
 
     @Schema(description = "파일 이름")
-    private String fileName;
+    private List<String> fileNameList = new ArrayList<>();
 }

--- a/src/main/java/com/games/balancegameback/dto/media/PresignedUrlsRequest.java
+++ b/src/main/java/com/games/balancegameback/dto/media/PresignedUrlsRequest.java
@@ -4,9 +4,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.util.ArrayList;
-import java.util.List;
-
 @Data
 @NoArgsConstructor
 public class PresignedUrlsRequest {
@@ -14,6 +11,6 @@ public class PresignedUrlsRequest {
     @Schema(description = "prefix")
     private String prefix;
 
-    @Schema(description = "파일 이름")
-    private List<String> fileNameList = new ArrayList<>();
+    @Schema(description = "업로드 개수")
+    private int length;
 }

--- a/src/main/java/com/games/balancegameback/infra/repository/media/MediaJpaRepository.java
+++ b/src/main/java/com/games/balancegameback/infra/repository/media/MediaJpaRepository.java
@@ -1,0 +1,10 @@
+package com.games.balancegameback.infra.repository.media;
+
+import com.games.balancegameback.infra.entity.MediaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MediaJpaRepository extends JpaRepository<MediaEntity, Long> {
+    
+}

--- a/src/main/java/com/games/balancegameback/infra/repository/media/MediaRepositoryImpl.java
+++ b/src/main/java/com/games/balancegameback/infra/repository/media/MediaRepositoryImpl.java
@@ -1,0 +1,13 @@
+package com.games.balancegameback.infra.repository.media;
+
+import com.games.balancegameback.service.media.MediaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class MediaRepositoryImpl implements MediaRepository {
+
+    private final MediaJpaRepository mediaRepository;
+
+}

--- a/src/main/java/com/games/balancegameback/infra/repository/user/UserJpaRepository.java
+++ b/src/main/java/com/games/balancegameback/infra/repository/user/UserJpaRepository.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Repository;
 import java.util.Optional;
 
 @Repository
-public interface UserJpaRepository extends JpaRepository<UsersEntity, Long> {
+public interface UserJpaRepository extends JpaRepository<UsersEntity, String> {
 
     Optional<UsersEntity> findByEmail(String email);
 

--- a/src/main/java/com/games/balancegameback/service/media/MediaRepository.java
+++ b/src/main/java/com/games/balancegameback/service/media/MediaRepository.java
@@ -1,0 +1,6 @@
+package com.games.balancegameback.service.media;
+
+public interface MediaRepository {
+
+
+}

--- a/src/main/java/com/games/balancegameback/service/media/MediaService.java
+++ b/src/main/java/com/games/balancegameback/service/media/MediaService.java
@@ -7,22 +7,20 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
 public class MediaService {
 
-    private final MediaRepository mediaRepository;
     private final ImageService imageService;
 
-    // Presigned URL 발급 (단일)
-    public Map<String, String> getPreSignedUrl(PresignedUrlRequest request) {
-        return imageService.getPreSignedUrl(request.getPrefix(), request.getFileName());
+    // Presigned URL 발급 (단일, 유저)
+    public String getPreSignedUrl(PresignedUrlRequest request) {
+        return imageService.getPreSignedUrl(null, request.getPrefix());
     }
 
     // Presigned URL 발급 (다중)
-    public List<Map<String, String>> getPreSignedUrls(PresignedUrlsRequest request) {
-        return imageService.getPreSignedUrls(request.getPrefix(), request.getFileNameList());
+    public List<String> getPreSignedUrls(Long roomId, PresignedUrlsRequest request) {
+        return imageService.getPreSignedUrls(roomId, request.getPrefix(), request.getLength());
     }
 }

--- a/src/main/java/com/games/balancegameback/service/media/MediaService.java
+++ b/src/main/java/com/games/balancegameback/service/media/MediaService.java
@@ -1,0 +1,19 @@
+package com.games.balancegameback.service.media;
+
+import com.games.balancegameback.dto.media.PresignedUrlRequest;
+import com.games.balancegameback.service.media.impl.ImageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MediaService {
+
+    private final MediaRepository mediaRepository;
+    private final ImageService imageService;
+
+    // Presigned URL 발급
+    public String getPreSignedUrl(PresignedUrlRequest request) {
+        return imageService.getPreSignedUrl(request.getPrefix(), request.getFileName());
+    }
+}

--- a/src/main/java/com/games/balancegameback/service/media/MediaService.java
+++ b/src/main/java/com/games/balancegameback/service/media/MediaService.java
@@ -2,7 +2,8 @@ package com.games.balancegameback.service.media;
 
 import com.games.balancegameback.dto.media.PresignedUrlRequest;
 import com.games.balancegameback.dto.media.PresignedUrlsRequest;
-import com.games.balancegameback.service.media.impl.ImageService;
+import com.games.balancegameback.service.media.impl.PresignedUrlService;
+import com.games.balancegameback.service.user.impl.UserUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -12,20 +13,17 @@ import java.util.List;
 @RequiredArgsConstructor
 public class MediaService {
 
-    private final ImageService imageService;
+    private final PresignedUrlService presignedUrlService;
+    private final UserUtils userUtils;
 
     // Presigned URL 발급 (단일, 유저)
     public String getPreSignedUrl(PresignedUrlRequest request) {
-        return imageService.getPreSignedUrl(null, request.getPrefix());
+        return presignedUrlService.getPreSignedUrl(request.getPrefix());
     }
 
     // Presigned URL 발급 (다중)
-    public List<String> getPreSignedUrls(Long roomId, PresignedUrlsRequest request) {
-        return imageService.getPreSignedUrls(roomId, request.getPrefix(), request.getLength());
-    }
-
-    // S3 내 객체와 DB 내 정보 validate
-    public boolean validateUploadedFile(Long roomId, String imageUrl) {
-        return imageService.isFileExistOnS3(roomId, imageUrl);
+    public List<String> getPreSignedUrls(Long roomId, String token, PresignedUrlsRequest request) {
+        // game 로직 완성 후 validate 로직 추가 예정.
+        return presignedUrlService.getPreSignedUrls(request.getPrefix(), request.getLength());
     }
 }

--- a/src/main/java/com/games/balancegameback/service/media/MediaService.java
+++ b/src/main/java/com/games/balancegameback/service/media/MediaService.java
@@ -23,4 +23,9 @@ public class MediaService {
     public List<String> getPreSignedUrls(Long roomId, PresignedUrlsRequest request) {
         return imageService.getPreSignedUrls(roomId, request.getPrefix(), request.getLength());
     }
+
+    // S3 내 객체와 DB 내 정보 validate
+    public boolean validateUploadedFile(Long roomId, String imageUrl) {
+        return imageService.isFileExistOnS3(roomId, imageUrl);
+    }
 }

--- a/src/main/java/com/games/balancegameback/service/media/MediaService.java
+++ b/src/main/java/com/games/balancegameback/service/media/MediaService.java
@@ -1,9 +1,13 @@
 package com.games.balancegameback.service.media;
 
 import com.games.balancegameback.dto.media.PresignedUrlRequest;
+import com.games.balancegameback.dto.media.PresignedUrlsRequest;
 import com.games.balancegameback.service.media.impl.ImageService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -12,8 +16,13 @@ public class MediaService {
     private final MediaRepository mediaRepository;
     private final ImageService imageService;
 
-    // Presigned URL 발급
-    public String getPreSignedUrl(PresignedUrlRequest request) {
+    // Presigned URL 발급 (단일)
+    public Map<String, String> getPreSignedUrl(PresignedUrlRequest request) {
         return imageService.getPreSignedUrl(request.getPrefix(), request.getFileName());
+    }
+
+    // Presigned URL 발급 (다중)
+    public List<Map<String, String>> getPreSignedUrls(PresignedUrlsRequest request) {
+        return imageService.getPreSignedUrls(request.getPrefix(), request.getFileNameList());
     }
 }

--- a/src/main/java/com/games/balancegameback/service/media/impl/ImageService.java
+++ b/src/main/java/com/games/balancegameback/service/media/impl/ImageService.java
@@ -1,0 +1,85 @@
+package com.games.balancegameback.service.media.impl;
+
+import com.games.balancegameback.core.exception.impl.BadRequestException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+import java.net.URL;
+import java.time.Duration;
+import java.util.UUID;
+
+import static com.games.balancegameback.core.exception.ErrorCode.RUNTIME_EXCEPTION;
+
+@Service
+@RequiredArgsConstructor
+public class ImageService {
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    private final S3Presigner s3Presigner;
+
+    /**
+     * Presigned URL 발급
+     * @param prefix 버킷 디렉토리 이름
+     * @param fileName 클라이언트가 전달한 파일명 파라미터
+     * @return Presigned URL
+     */
+    public String getPreSignedUrl(String prefix, String fileName) {
+        if (prefix != null && !prefix.isEmpty()) {
+            fileName = createPath(prefix, fileName);
+        }
+
+        // Presigned URL 생성
+        PresignedPutObjectRequest presignedRequest = generatePreSignedUrlRequest(bucket, fileName);
+        URL url = presignedRequest.url();
+        return url.toString();
+    }
+
+    /**
+     * 파일 업로드용(PUT) presigned url 생성
+     * @param bucket 버킷 이름
+     * @param fileName S3 업로드용 파일 이름
+     * @return Presigned URL
+     */
+    private PresignedPutObjectRequest generatePreSignedUrlRequest(String bucket, String fileName) {
+        // PutObjectRequest 설정
+        PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                .bucket(bucket)
+                .key(fileName)
+                .build();
+
+        // Presign 요청 설정
+        PutObjectPresignRequest presignRequest = PutObjectPresignRequest.builder()
+                .putObjectRequest(putObjectRequest)
+                .signatureDuration(Duration.ofMinutes(2)) // 유효 시간 2분
+                .build();
+
+        // Presigned URL 생성
+        return s3Presigner.presignPutObject(presignRequest);
+    }
+
+    /**
+     * 파일 고유 ID를 생성
+     * @return 36자리의 UUID
+     */
+    private String createFileId() {
+        return UUID.randomUUID().toString();
+    }
+
+    /**
+     * 파일의 전체 경로를 생성
+     * @param prefix 디렉토리 경로
+     * @param fileName 파일 이름
+     * @return 파일의 전체 경로
+     */
+    private String createPath(String prefix, String fileName) {
+        String fileId = createFileId();
+        return String.format("%s/%s%s", prefix, fileId, fileName);
+    }
+}

--- a/src/main/java/com/games/balancegameback/service/media/impl/PresignedUrlService.java
+++ b/src/main/java/com/games/balancegameback/service/media/impl/PresignedUrlService.java
@@ -2,13 +2,10 @@ package com.games.balancegameback.service.media.impl;
 
 import com.games.balancegameback.core.exception.ErrorCode;
 import com.games.balancegameback.core.exception.impl.BadRequestException;
-import com.games.balancegameback.service.media.MediaRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import software.amazon.awssdk.regions.Region;
-import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
@@ -20,28 +17,25 @@ import java.util.*;
 
 @Service
 @RequiredArgsConstructor
-public class ImageService {
+public class PresignedUrlService {
 
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
 
     private final S3Presigner s3Presigner;
-    private final S3Client s3Client;
-    private final MediaRepository mediaRepository;
     private static final Region REGION = Region.AP_NORTHEAST_2;
 
     /**
      * Presigned URL 발급
      * @param prefix 버킷 디렉토리 이름
-     * @param roomId 게임방 id
      * @return Presigned URL
      */
-    public String getPreSignedUrl(Long roomId, String prefix) {
+    public String getPreSignedUrl(String prefix) {
         if (prefix == null || prefix.isEmpty()) {
             throw new BadRequestException("prefix 값이 잘못되었습니다.", ErrorCode.RUNTIME_EXCEPTION);
         }
 
-        String fileName = createPath(roomId, prefix);
+        String fileName = createPath(prefix);
 
         // Presigned URL 생성
         PresignedPutObjectRequest presignedRequest = generatePreSignedUrlRequest(bucket, fileName);
@@ -53,47 +47,18 @@ public class ImageService {
 
     /**
      * 여러 장의 Presigned URL 발급 및 S3 URL 반환
-     * @param roomId 게임방 id
      * @param prefix 버킷 디렉토리 이름
      * @param length 클라이언트가 전달한 파일 갯수
      * @return List<String> (presignedUrl, finalUrl)
      */
-    public List<String> getPreSignedUrls(Long roomId, String prefix, int length) {
+    public List<String> getPreSignedUrls(String prefix, int length) {
         List<String> urls = new ArrayList<>();
 
         for (int i = 0; i < length; i++) {
-            urls.add(getPreSignedUrl(roomId, prefix));
+            urls.add(getPreSignedUrl(prefix));
         }
 
         return urls;
-    }
-
-    /**
-     * 주어진 S3 객체 URL을 통해 해당 객체가 존재하는지 확인
-     * @param roomId 게임방 Id
-     * @param imageUrl S3 객체의 URL
-     * @return true / false
-     */
-    public boolean isFileExistOnS3(Long roomId, String imageUrl) {
-        String key = extractKeyFromUrl(imageUrl);
-        try {
-            s3Client.headObject(HeadObjectRequest.builder()
-                    .bucket(bucket)
-                    .key(key)
-                    .build());
-            return true;
-        } catch (Exception e) {
-            return false;
-        }
-    }
-
-    /**
-     * S3 객체 키(Key) 추출
-     * @param imageUrl S3 객체의 URL
-     * @return 객체 키 (S3 내 경로)
-     */
-    private String extractKeyFromUrl(String imageUrl) {
-        return imageUrl.split(".amazonaws.com/")[1];
     }
 
     /**
@@ -132,7 +97,7 @@ public class ImageService {
      * @param prefix 디렉토리 경로
      * @return 파일의 전체 경로
      */
-    private String createPath(Long roomId, String prefix) {
+    private String createPath(String prefix) {
         String fileId = createFileId();
         return String.format("%s/%s", prefix, fileId);
     }

--- a/src/main/java/com/games/balancegameback/web/media/PresignedUrlController.java
+++ b/src/main/java/com/games/balancegameback/web/media/PresignedUrlController.java
@@ -8,38 +8,37 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
-import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping(value = "/api/v1/media/upload")
+@RequestMapping(value = "/api/v1/media")
 @Tag(name = "Presigned URL Controller", description = "Media Upload & Update API")
 public class PresignedUrlController {
 
     private final MediaService mediaService;
 
-    @Operation(summary = "단일 업로드 API", description = "AWS S3 저장소에 업로드할 수 있는 단일 URL 발급")
+    @Operation(summary = "단일 업로드 API (User Profile)", description = "AWS S3 저장소에 업로드할 수 있는 단일 URL 발급")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "URL 발급 성공")
+            @ApiResponse(responseCode = "200", description = "URL 발급 성공"),
+            @ApiResponse(responseCode = "400", description = "prefix 값이 확인되지 않음.")
     })
-    @PostMapping(value = "/singular")
-    public Map<String, String> getPreSignedUrl(@RequestBody PresignedUrlRequest request) {
+    @PostMapping(value = "/single")
+    public String getPreSignedUrlForUser(@RequestBody PresignedUrlRequest request) {
         return mediaService.getPreSignedUrl(request);
     }
 
 
     @Operation(summary = "다중 업로드 API", description = "AWS S3 저장소에 업로드할 수 있는 다중 URL 발급")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "URL 발급 성공")
+            @ApiResponse(responseCode = "200", description = "URL 발급 성공"),
+            @ApiResponse(responseCode = "400", description = "prefix 값이 확인되지 않음.")
     })
-    @PostMapping(value = "/plural")
-    public List<Map<String, String>> getPreSignedUrl(@RequestBody PresignedUrlsRequest request) {
-        return mediaService.getPreSignedUrls(request);
+    @PostMapping(value = "/multiple")
+    public List<String> getPreSignedUrl(@RequestParam(value = "roomId") Long roomId,
+                                                     @RequestBody PresignedUrlsRequest request) {
+        return mediaService.getPreSignedUrls(roomId, request);
     }
 }

--- a/src/main/java/com/games/balancegameback/web/media/PresignedUrlController.java
+++ b/src/main/java/com/games/balancegameback/web/media/PresignedUrlController.java
@@ -35,10 +35,12 @@ public class PresignedUrlController {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "URL 발급 성공"),
             @ApiResponse(responseCode = "400", description = "prefix 값이 확인되지 않음.")
+            // @ApiResponse(responseCode = "401", description = "인증 실패")
     })
     @PostMapping(value = "/multiple")
-    public List<String> getPreSignedUrl(@RequestParam(value = "roomId", defaultValue = "1") Long roomId,
-                                                     @RequestBody PresignedUrlsRequest request) {
-        return mediaService.getPreSignedUrls(roomId, request);
+    public List<String> getPreSignedUrl(@RequestBody PresignedUrlsRequest request,
+                                        @RequestHeader("Authorization") String token,
+                                        @RequestParam(value = "roomId") Long roomId) {
+        return mediaService.getPreSignedUrls(roomId, token, request);
     }
 }

--- a/src/main/java/com/games/balancegameback/web/media/PresignedUrlController.java
+++ b/src/main/java/com/games/balancegameback/web/media/PresignedUrlController.java
@@ -37,7 +37,7 @@ public class PresignedUrlController {
             @ApiResponse(responseCode = "400", description = "prefix 값이 확인되지 않음.")
     })
     @PostMapping(value = "/multiple")
-    public List<String> getPreSignedUrl(@RequestParam(value = "roomId") Long roomId,
+    public List<String> getPreSignedUrl(@RequestParam(value = "roomId", defaultValue = "1") Long roomId,
                                                      @RequestBody PresignedUrlsRequest request) {
         return mediaService.getPreSignedUrls(roomId, request);
     }

--- a/src/main/java/com/games/balancegameback/web/media/PresignedUrlController.java
+++ b/src/main/java/com/games/balancegameback/web/media/PresignedUrlController.java
@@ -1,6 +1,7 @@
 package com.games.balancegameback.web.media;
 
 import com.games.balancegameback.dto.media.PresignedUrlRequest;
+import com.games.balancegameback.dto.media.PresignedUrlsRequest;
 import com.games.balancegameback.service.media.MediaService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -12,20 +13,33 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
+import java.util.Map;
+
 @RestController
 @RequiredArgsConstructor
-@RequestMapping(value = "/api/v1/media")
+@RequestMapping(value = "/api/v1/media/upload")
 @Tag(name = "Presigned URL Controller", description = "Media Upload & Update API")
 public class PresignedUrlController {
 
     private final MediaService mediaService;
 
-    @Operation(summary = "업로드 API", description = "AWS S3 저장소에 업로드할 수 있는 URL 발급")
+    @Operation(summary = "단일 업로드 API", description = "AWS S3 저장소에 업로드할 수 있는 단일 URL 발급")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "URL 발급 성공")
     })
-    @PostMapping(value = "/upload")
-    public String getPreSignedUrl(@RequestBody PresignedUrlRequest request) {
+    @PostMapping(value = "/singular")
+    public Map<String, String> getPreSignedUrl(@RequestBody PresignedUrlRequest request) {
         return mediaService.getPreSignedUrl(request);
+    }
+
+
+    @Operation(summary = "다중 업로드 API", description = "AWS S3 저장소에 업로드할 수 있는 다중 URL 발급")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "URL 발급 성공")
+    })
+    @PostMapping(value = "/plural")
+    public List<Map<String, String>> getPreSignedUrl(@RequestBody PresignedUrlsRequest request) {
+        return mediaService.getPreSignedUrls(request);
     }
 }

--- a/src/main/java/com/games/balancegameback/web/media/PresignedUrlController.java
+++ b/src/main/java/com/games/balancegameback/web/media/PresignedUrlController.java
@@ -1,0 +1,31 @@
+package com.games.balancegameback.web.media;
+
+import com.games.balancegameback.dto.media.PresignedUrlRequest;
+import com.games.balancegameback.service.media.MediaService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping(value = "/api/v1/media")
+@Tag(name = "Presigned URL Controller", description = "Media Upload & Update API")
+public class PresignedUrlController {
+
+    private final MediaService mediaService;
+
+    @Operation(summary = "업로드 API", description = "AWS S3 저장소에 업로드할 수 있는 URL 발급")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "URL 발급 성공")
+    })
+    @PostMapping(value = "/upload")
+    public String getPreSignedUrl(@RequestBody PresignedUrlRequest request) {
+        return mediaService.getPreSignedUrl(request);
+    }
+}


### PR DESCRIPTION
## 작업내용 설명
- 클라이언트 측에서 API 를 호출하면 Presigned URL 을 발급함.
- 단일 저장, 다중 저장을 지원하며 발급한 URL 의 수명은 2분으로 제한함.

## 관련 이슈
- https://github.com/Rookeys/balance-game-back/issues/2

## PR 유형
어떤 변경 사항이 있는지 체크해주세요.

- [ ] 버그 수정
- [x] 새로운 기능 추가
- [ ] 사용자 UI 디자인 변경
- [ ] 코드 리팩토링
- [ ] 테스트 추가
- [ ] 기타 (내용을 적어주세요) :

## PR 체크리스트
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 로컬 빌드가 정상적으로 실행되었습니다.
- [x] PR 작업에 대한 테스트를 완료하였습니다.