### PR TITLE
Chore: Media 엔티티를 추상 클래스로 구조 변경.

### DIFF
--- a/src/main/java/com/games/balancegameback/domain/game/GameResources.java
+++ b/src/main/java/com/games/balancegameback/domain/game/GameResources.java
@@ -1,9 +1,10 @@
 package com.games.balancegameback.domain.game;
 
-import com.games.balancegameback.domain.media.Media;
+import com.games.balancegameback.domain.media.Images;
+import com.games.balancegameback.domain.media.Links;
 import lombok.Builder;
 
-public record GameResources(Long id, String title, Games games, Media media) {
+public record GameResources(Long id, String title, Games games, Links links, Images images) {
 
     @Builder
     public GameResources {

--- a/src/main/java/com/games/balancegameback/domain/game/GameResults.java
+++ b/src/main/java/com/games/balancegameback/domain/game/GameResults.java
@@ -1,9 +1,10 @@
 package com.games.balancegameback.domain.game;
 
-import com.games.balancegameback.domain.media.Media;
+import com.games.balancegameback.domain.media.Images;
+import com.games.balancegameback.domain.media.Links;
 import lombok.Builder;
 
-public record GameResults(Long id, Games games, Media media) {
+public record GameResults(Long id, Games games, Images images, Links links) {
 
     @Builder
     public GameResults {

--- a/src/main/java/com/games/balancegameback/domain/media/Images.java
+++ b/src/main/java/com/games/balancegameback/domain/media/Images.java
@@ -2,7 +2,7 @@ package com.games.balancegameback.domain.media;
 
 import lombok.Builder;
 
-public record Images(Long id, String fileName, String fileUrl, Media media) {
+public record Images(Long id, String fileName, String fileUrl) implements Media {
 
     @Builder
     public Images {

--- a/src/main/java/com/games/balancegameback/domain/media/Links.java
+++ b/src/main/java/com/games/balancegameback/domain/media/Links.java
@@ -2,7 +2,7 @@ package com.games.balancegameback.domain.media;
 
 import lombok.Builder;
 
-public record Links(Long id, String urls, int startSec, int endSec, Media media) {
+public record Links(Long id, String urls, int startSec, int endSec) implements Media {
 
     @Builder
     public Links {

--- a/src/main/java/com/games/balancegameback/domain/media/Media.java
+++ b/src/main/java/com/games/balancegameback/domain/media/Media.java
@@ -1,15 +1,5 @@
 package com.games.balancegameback.domain.media;
 
-import com.games.balancegameback.domain.game.Games;
-import com.games.balancegameback.domain.media.enums.MediaType;
-import com.games.balancegameback.domain.media.enums.UsingType;
-import com.games.balancegameback.domain.user.Users;
-import lombok.Builder;
-
-public record Media(Long id, MediaType mediaType, UsingType usingType, Users user, Games game) {
-
-    @Builder
-    public Media {
-
-    }
+public interface Media {
+    Long id();
 }

--- a/src/main/java/com/games/balancegameback/infra/entity/GameResourcesEntity.java
+++ b/src/main/java/com/games/balancegameback/infra/entity/GameResourcesEntity.java
@@ -1,7 +1,6 @@
 package com.games.balancegameback.infra.entity;
 
 import com.games.balancegameback.domain.game.GameResources;
-import com.games.balancegameback.domain.game.GameResults;
 import jakarta.persistence.*;
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
@@ -34,14 +33,25 @@ public class GameResourcesEntity {
     private GamesEntity games;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "media_id")
-    private MediaEntity media;
+    @JoinColumn(name = "images_id")
+    private ImagesEntity images;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "links_id")
+    private LinksEntity links;
 
     public static GameResourcesEntity from(GameResources gameResources) {
         GameResourcesEntity gameResourcesEntity = new GameResourcesEntity();
         gameResourcesEntity.title = gameResources.title();
         gameResourcesEntity.games = GamesEntity.from(gameResources.games());
-        gameResourcesEntity.media = MediaEntity.from(gameResources.media());
+
+        if (gameResources.images() != null) {
+            gameResourcesEntity.images = ImagesEntity.from(gameResources.images());
+        }
+
+        if (gameResources.links() != null) {
+            gameResourcesEntity.links = LinksEntity.from(gameResources.links());
+        }
 
         return gameResourcesEntity;
     }
@@ -51,7 +61,8 @@ public class GameResourcesEntity {
                 .id(id)
                 .title(title)
                 .games(games.toModel())
-                .media(media.toModel())
+                .images(images != null ? images.toModel() : null)
+                .links(links != null ? links.toModel() : null)
                 .build();
     }
 }

--- a/src/main/java/com/games/balancegameback/infra/entity/GameResultsEntity.java
+++ b/src/main/java/com/games/balancegameback/infra/entity/GameResultsEntity.java
@@ -1,7 +1,6 @@
 package com.games.balancegameback.infra.entity;
 
 import com.games.balancegameback.domain.game.GameResults;
-import com.games.balancegameback.domain.media.Links;
 import jakarta.persistence.*;
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
@@ -26,13 +25,24 @@ public class GameResultsEntity {
     private GamesEntity games;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "media_id")
-    private MediaEntity media;
+    @JoinColumn(name = "images_id")
+    private ImagesEntity images;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "links_id")
+    private LinksEntity links;
 
     public static GameResultsEntity from(GameResults gameResults) {
         GameResultsEntity gameResultsEntity = new GameResultsEntity();
         gameResultsEntity.games = GamesEntity.from(gameResults.games());
-        gameResultsEntity.media = MediaEntity.from(gameResults.media());
+
+        if (gameResults.images() != null) {
+            gameResultsEntity.images = ImagesEntity.from(gameResults.images());
+        }
+
+        if (gameResults.links() != null) {
+            gameResultsEntity.links = LinksEntity.from(gameResults.links());
+        }
 
         return gameResultsEntity;
     }
@@ -41,7 +51,8 @@ public class GameResultsEntity {
         return GameResults.builder()
                 .id(id)
                 .games(games.toModel())
-                .media(media.toModel())
+                .images(images != null ? images.toModel() : null)
+                .links(links != null ? links.toModel() : null)
                 .build();
     }
 }

--- a/src/main/java/com/games/balancegameback/infra/entity/ImagesEntity.java
+++ b/src/main/java/com/games/balancegameback/infra/entity/ImagesEntity.java
@@ -1,21 +1,14 @@
 package com.games.balancegameback.infra.entity;
 
 import com.games.balancegameback.domain.media.Images;
-import com.games.balancegameback.domain.media.Links;
 import jakarta.persistence.*;
 import lombok.Getter;
-import org.springframework.data.annotation.CreatedDate;
-
-import java.time.LocalDateTime;
 
 @Getter
 @Entity
+@DiscriminatorValue("IMAGE")
 @Table(name = "images")
-public class ImagesEntity {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+public class ImagesEntity extends MediaEntity {
 
     @Column(nullable = false)
     private String fileName;
@@ -23,29 +16,20 @@ public class ImagesEntity {
     @Column(nullable = false)
     private String fileUrl;
 
-    @Column(updatable = false)
-    @CreatedDate
-    private LocalDateTime createdDate;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "media_id")
-    private MediaEntity media;
-
     public static ImagesEntity from(Images images) {
         ImagesEntity imagesEntity = new ImagesEntity();
         imagesEntity.fileName = images.fileName();
         imagesEntity.fileUrl = images.fileUrl();
-        imagesEntity.media = MediaEntity.from(images.media());
 
         return imagesEntity;
     }
 
+    @Override
     public Images toModel() {
         return Images.builder()
-                .id(id)
+                .id(this.getId())
                 .fileName(fileName)
                 .fileUrl(fileUrl)
-                .media(media.toModel())
                 .build();
     }
 }

--- a/src/main/java/com/games/balancegameback/infra/entity/LinksEntity.java
+++ b/src/main/java/com/games/balancegameback/infra/entity/LinksEntity.java
@@ -10,12 +10,9 @@ import java.time.LocalDateTime;
 
 @Getter
 @Entity
+@DiscriminatorValue("LINK")
 @Table(name = "links")
-public class LinksEntity {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+public class LinksEntity extends MediaEntity {
 
     @Column(nullable = false)
     private String urls;
@@ -26,31 +23,22 @@ public class LinksEntity {
     @Column
     private int endSec;
 
-    @Column(updatable = false)
-    @CreatedDate
-    private LocalDateTime createdDate;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "media_id", nullable = false)
-    private MediaEntity media;
-
     public static LinksEntity from(Links links) {
         LinksEntity linksEntity = new LinksEntity();
         linksEntity.urls = links.urls();
         linksEntity.startSec = links.startSec();
         linksEntity.endSec = links.endSec();
-        linksEntity.media = MediaEntity.from(links.media());
 
         return linksEntity;
     }
 
+    @Override
     public Links toModel() {
         return Links.builder()
-                .id(id)
+                .id(this.getId())
                 .urls(urls)
                 .startSec(startSec)
                 .endSec(endSec)
-                .media(media.toModel())
                 .build();
     }
 }

--- a/src/main/java/com/games/balancegameback/infra/entity/MediaEntity.java
+++ b/src/main/java/com/games/balancegameback/infra/entity/MediaEntity.java
@@ -1,8 +1,6 @@
 package com.games.balancegameback.infra.entity;
 
 import com.games.balancegameback.domain.media.Media;
-import com.games.balancegameback.domain.media.enums.MediaType;
-import com.games.balancegameback.domain.media.enums.UsingType;
 import jakarta.persistence.*;
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
@@ -11,20 +9,14 @@ import java.time.LocalDateTime;
 
 @Getter
 @Entity
+@Inheritance(strategy = InheritanceType.JOINED)
+@DiscriminatorColumn(name = "media_type", discriminatorType = DiscriminatorType.STRING)
 @Table(name = "media")
-public class MediaEntity {
+public abstract class MediaEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-
-    @Column(nullable = false)
-    @Enumerated(EnumType.STRING)
-    private MediaType mediaType;
-
-    @Column(nullable = false)
-    @Enumerated(EnumType.STRING)
-    private UsingType usingType;
 
     @Column(updatable = false)
     @CreatedDate
@@ -38,24 +30,6 @@ public class MediaEntity {
     @JoinColumn(name = "games_id")
     private GamesEntity games;
 
-    public static MediaEntity from(Media media) {
-        MediaEntity mediaEntity = new MediaEntity();
-        mediaEntity.mediaType = media.mediaType();
-        mediaEntity.usingType = media.usingType();
-        mediaEntity.users = UsersEntity.from(media.user());
-        mediaEntity.games = GamesEntity.from(media.game());
-
-        return mediaEntity;
-    }
-
-    public Media toModel() {
-        return Media.builder()
-                .id(id)
-                .mediaType(mediaType)
-                .usingType(usingType)
-                .user(users.toModel())
-                .game(games.toModel())
-                .build();
-    }
+    public abstract Media toModel();
 }
 

--- a/src/main/java/com/games/balancegameback/infra/repository/media/MediaRepositoryImpl.java
+++ b/src/main/java/com/games/balancegameback/infra/repository/media/MediaRepositoryImpl.java
@@ -1,6 +1,6 @@
 package com.games.balancegameback.infra.repository.media;
 
-import com.games.balancegameback.service.media.MediaRepository;
+import com.games.balancegameback.service.media.repository.MediaRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/com/games/balancegameback/service/media/MediaRepository.java
+++ b/src/main/java/com/games/balancegameback/service/media/MediaRepository.java
@@ -1,6 +1,0 @@
-package com.games.balancegameback.service.media;
-
-public interface MediaRepository {
-
-
-}

--- a/src/main/java/com/games/balancegameback/service/media/impl/LinkService.java
+++ b/src/main/java/com/games/balancegameback/service/media/impl/LinkService.java
@@ -1,0 +1,14 @@
+package com.games.balancegameback.service.media.impl;
+
+import com.games.balancegameback.service.media.repository.LinkRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class LinkService {
+
+    private final LinkRepository linkRepository;
+
+
+}

--- a/src/main/java/com/games/balancegameback/service/media/repository/LinkRepository.java
+++ b/src/main/java/com/games/balancegameback/service/media/repository/LinkRepository.java
@@ -1,0 +1,5 @@
+package com.games.balancegameback.service.media.repository;
+
+public interface LinkRepository {
+
+}

--- a/src/main/java/com/games/balancegameback/service/media/repository/MediaRepository.java
+++ b/src/main/java/com/games/balancegameback/service/media/repository/MediaRepository.java
@@ -1,0 +1,6 @@
+package com.games.balancegameback.service.media.repository;
+
+public interface MediaRepository {
+
+
+}


### PR DESCRIPTION
## 작업내용 설명
- 기존 Media 엔티티 구조가 확장성은 높지만 사용하기 불편하단 단점이 있었는데, 이를 추상 클래스로 만들어 버림으로써 확장성과 사용성 모두 챙길 수 있는 리팩토링 작업을 진행했습니다.

## 관련 이슈
- https://github.com/Rookeys/balance-game-back/issues/6


## PR 유형
어떤 변경 사항이 있는지 체크해주세요.

- [ ] 버그 수정
- [ ] 새로운 기능 추가
- [ ] 사용자 UI 디자인 변경
- [x] 코드 리팩토링
- [ ] 테스트 추가
- [ ] 기타 (내용을 적어주세요) :

## PR 체크리스트
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 로컬 빌드가 정상적으로 실행되었습니다.
- [x] PR 작업에 대한 테스트를 완료하였습니다.