### PR TITLE
데이터 중복 제거 및 인증 불필요 api 들을 시큐리티에서 제외

### DIFF
--- a/src/main/java/com/games/balancegameback/core/jwt/JwtAuthenticationTokenFilter.java
+++ b/src/main/java/com/games/balancegameback/core/jwt/JwtAuthenticationTokenFilter.java
@@ -10,7 +10,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
-import lombok.extern.log4j.Log4j2;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -25,14 +24,14 @@ import java.util.Set;
 
 @RequiredArgsConstructor
 @Component
-@Log4j2
 public class JwtAuthenticationTokenFilter extends OncePerRequestFilter {
 
     private static final Set<String> EXCLUDED_PATHS = Set.of(
             "/swagger-ui/**", "/v3/api-docs/**", "/api/v1/users/login/kakao", "/api/v1/users/test/login",
             "/api/v1/users/login", "/api/v1/users/signup", "/api/v1/media/single", "/api/v1/media/multiple",
             "/api/v1/users/exists", "/api/v1/games/{gameId}/play", "/api/v1/games/{gameId}/play/{playId}",
-            "/api/v1/games/{gameId}/results"
+            "/api/v1/games/resources/{resourceId}/comments", "/api/v1/games/resources/{resourceId}/comments/{parentId}",
+            "/api/v1/games/{gameId}/results", "/api/v1/games/{gameId}/results/comments"
     );
 
     private static final Set<String> REQUIRED_PATHS = Set.of(

--- a/src/main/java/com/games/balancegameback/infra/repository/game/impl/GameResourceCommentRepositoryImpl.java
+++ b/src/main/java/com/games/balancegameback/infra/repository/game/impl/GameResourceCommentRepositoryImpl.java
@@ -71,12 +71,12 @@ public class GameResourceCommentRepositoryImpl implements GameResourceCommentRep
 
         this.setOptions(builder, cursorId, request, comments);
         // 비로그인 회원은 좋아요를 표시했는지 안했는지 모르기 때문에 조건 추가.
-        BooleanExpression leftJoinCondition = users != null ? comments.users.email.eq(users.getEmail()) : null;
+        BooleanExpression leftJoinCondition = users != null ? comments.users.email.eq(users.getEmail()) : Expressions.FALSE;
 
         OrderSpecifier<?> orderSpecifier = this.getOrderSpecifier(request.getSortType());
 
         List<GameResourceParentCommentResponse> list = jpaQueryFactory
-                .select(Projections.constructor(
+                .selectDistinct(Projections.constructor(
                         GameResourceParentCommentResponse.class,
                         comments.id.as("commentId"),
                         comments.comment.as("comment"),
@@ -121,12 +121,12 @@ public class GameResourceCommentRepositoryImpl implements GameResourceCommentRep
 
         this.setOptions(builder, cursorId, request, comments);
         // 비로그인 회원은 좋아요를 표시했는지 안했는지 모르기 때문에 조건 추가.
-        BooleanExpression leftJoinCondition = users != null ? comments.users.email.eq(users.getEmail()) : null;
+        BooleanExpression leftJoinCondition = users != null ? comments.users.email.eq(users.getEmail()) : Expressions.FALSE;
 
         OrderSpecifier<?> orderSpecifier = this.getOrderSpecifier(request.getSortType());
 
         List<GameResourceChildrenCommentResponse> list = jpaQueryFactory
-                .select(Projections.constructor(
+                .selectDistinct(Projections.constructor(
                         GameResourceChildrenCommentResponse.class,
                         comments.id.as("commentId"),
                         comments.comment.as("comment"),

--- a/src/main/java/com/games/balancegameback/infra/repository/game/impl/GameResultCommentRepositoryImpl.java
+++ b/src/main/java/com/games/balancegameback/infra/repository/game/impl/GameResultCommentRepositoryImpl.java
@@ -63,12 +63,12 @@ public class GameResultCommentRepositoryImpl implements GameResultCommentReposit
 
         this.setOptions(builder, cursorId, searchRequest, comments);
         // 비로그인 회원은 좋아요를 표시했는지 안했는지 모르기 때문에 조건 추가.
-        BooleanExpression leftJoinCondition = users != null ? comments.users.email.eq(users.getEmail()) : null;
+        BooleanExpression leftJoinCondition = users != null ? comments.users.email.eq(users.getEmail()) : Expressions.FALSE;
 
         OrderSpecifier<?> orderSpecifier = this.getOrderSpecifier(searchRequest.getSortType());
 
         List<GameResultCommentResponse> list = jpaQueryFactory
-                .select(Projections.constructor(
+                .selectDistinct(Projections.constructor(
                         GameResultCommentResponse.class,
                         comments.id.as("commentId"),
                         comments.comment.as("comment"),

--- a/src/main/java/com/games/balancegameback/web/game/GameResourceCommentController.java
+++ b/src/main/java/com/games/balancegameback/web/game/GameResourceCommentController.java
@@ -29,7 +29,6 @@ public class GameResourceCommentController {
     private final GameService gameService;
 
     @Operation(summary = "게임 리소스 부모 댓글 리스트 발급 API", description = "게임 리소스 부모 댓글 리스트 목록을 제공한다.")
-    @SecurityRequirement(name = "bearerAuth")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "발급 완료")
     })
@@ -64,7 +63,6 @@ public class GameResourceCommentController {
     }
 
     @Operation(summary = "게임 리소스 대댓글 리스트 발급 API", description = "게임 리소스 대댓글 리스트 목록을 제공한다.")
-    @SecurityRequirement(name = "bearerAuth")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "발급 완료")
     })

--- a/src/main/java/com/games/balancegameback/web/game/GameResultCommentController.java
+++ b/src/main/java/com/games/balancegameback/web/game/GameResultCommentController.java
@@ -29,7 +29,6 @@ public class GameResultCommentController {
     private final GameService gameService;
 
     @Operation(summary = "게임 결과 댓글 리스트 발급 API", description = "게임 결과 댓글 리스트 목록을 제공한다.")
-    @SecurityRequirement(name = "bearerAuth")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "발급 완료")
     })


### PR DESCRIPTION
## 작업내용 설명
- @UniqueConstraint 로 두 id 를 엮은 탓에 데이터 조회를 할 때 1+1 문제가 발생함.
  - Distinct 로 해결할 수 있는 문제임을 확인하고 Distinct 를 추가해서 해결함.
- 로그인한 유저와 비회원 유저를 구별하여 자신이 누른 좋아요 유무를 출력할 때 비회원일 경우 null 이 발생해 에러가 발생함.
  - BooleanExpression 에서 람다식의 false 부분을 Expressions.FALSE 로 대체하여 해결함.
- Swagger 에서 토큰이 필요 없는 부분도 인증을 받도록 설정되어 있었던 부분을 수정함.

## 관련 이슈
- https://github.com/Rookeys/balance-game-back/issues/25

## PR 유형
- [x] 버그 수정
- [ ] 새로운 기능 추가
- [ ] 사용자 UI 디자인 변경
- [x] 코드 리팩토링
- [ ] 테스트 추가
- [ ] 기타 (내용을 적어주세요) :

## PR 체크리스트
- [x] 로컬 빌드가 정상적으로 실행되었습니다.
- [x] PR 작업에 대한 테스트를 완료하였습니다.