### PR TITLE
메인 페이지 반환값 일부 수정 및 추가

### DIFF
--- a/src/main/java/com/games/balancegameback/core/exception/ErrorCode.java
+++ b/src/main/java/com/games/balancegameback/core/exception/ErrorCode.java
@@ -10,6 +10,7 @@ public enum ErrorCode {
     RUNTIME_EXCEPTION(400, "400", "400 Bad Request"),
     INVITE_CODE_NULL_EXCEPTION(400, "400_1", "Invite Code Null"),
     CLOSED_PLAYROOM_EXCEPTION(400, "400_2", "Already Closed PlayRoom!!"),
+    INVALID_ROUND_EXCEPTION(400, "400_3", "Invalid Round"),
     ACCESS_DENIED_EXCEPTION(401, "401", "401 UnAuthorized"),
     NOT_ALLOW_WRITE_EXCEPTION(401, "401_1", "Not Allow"),
     NOT_ALLOW_RESIGN_EXCEPTION(401, "401_2", "Already resigned user."),

--- a/src/main/java/com/games/balancegameback/core/exception/ErrorEntity.java
+++ b/src/main/java/com/games/balancegameback/core/exception/ErrorEntity.java
@@ -1,21 +1,11 @@
 package com.games.balancegameback.core.exception;
 
 import lombok.Builder;
-import lombok.Getter;
-import lombok.ToString;
 
-@Getter
-@ToString
-public class ErrorEntity {
-
-    private int status;
-    private String errorCode;
-    private String errorMessage;
+public record ErrorEntity(int status, String errorCode, String errorMessage) {
 
     @Builder
-    public ErrorEntity(int status, String errorCode, String errorMessage) {
-        this.status = status;
-        this.errorCode = errorCode;
-        this.errorMessage = errorMessage;
+    public ErrorEntity {
+
     }
 }

--- a/src/main/java/com/games/balancegameback/domain/game/Games.java
+++ b/src/main/java/com/games/balancegameback/domain/game/Games.java
@@ -21,12 +21,12 @@ public class Games {
     private Category category;
     private final Users users;
     private GameInviteCode gameInviteCode;
-    private List<GameResourcesEntity> gameResources;
+    private List<GameResources> gameResources;
 
     @Builder
     public Games(Long id, String title, String description, Boolean isNamePublic, AccessType accessType,
                  Category category, Users users, GameInviteCode gameInviteCode,
-                 List<GameResourcesEntity> gameResources) {
+                 List<GameResources> gameResources) {
         this.id = id;
         this.title = title;
         this.description = description;

--- a/src/main/java/com/games/balancegameback/dto/game/GameListResponse.java
+++ b/src/main/java/com/games/balancegameback/dto/game/GameListResponse.java
@@ -24,6 +24,9 @@ public class GameListResponse {
     @Schema(description = "설명")
     private String description;
 
+    @Schema(description = "총 플레이 횟수")
+    private int totalPlayNums;
+
     @Schema(description = "왼쪽 선택지")
     private GameListSelectionResponse leftSelection;
 

--- a/src/main/java/com/games/balancegameback/service/game/impl/GamePlayService.java
+++ b/src/main/java/com/games/balancegameback/service/game/impl/GamePlayService.java
@@ -96,6 +96,11 @@ public class GamePlayService {
      */
     @Transactional
     public GamePlayResponse createPlayRoom(Long gameId, GamePlayRoundRequest roundRequest, HttpServletRequest request) {
+
+        if (!gameRepository.existsGameRounds(gameId, roundRequest.getRoundNumber())) {
+            throw new BadRequestException("리소스 수보다 많은 라운드는 실행할 수 없습니다.", ErrorCode.INVALID_ROUND_EXCEPTION);
+        }
+
         Games games = gameRepository.findByRoomId(gameId);
 
         if (games.getAccessType().equals(AccessType.PROTECTED)) {

--- a/src/main/java/com/games/balancegameback/service/game/repository/GameRepository.java
+++ b/src/main/java/com/games/balancegameback/service/game/repository/GameRepository.java
@@ -20,6 +20,8 @@ public interface GameRepository {
 
     boolean existsByIdAndUsers(Long gameId, Users users);
 
+    boolean existsGameRounds(Long gameId, int roundNumber);
+
     void update(Games games);
 
     void deleteById(Long roomId);


### PR DESCRIPTION
## 작업내용 설명
- 메인 페이지의 반환값 중 일부를 수정할 필요가 있어 수정 및 일부 추가함.
- 리소스가 2개 이하인 게임은 게임 목록에서 제외하도록 필터를 추가함.
- 내가 만든 게임 api 같은 경우엔 리소스가 2개 이하이더라도 보이도록 유지함.
- 해당 게임방의 총 플레이 횟수를 추가함.

## 관련 이슈
- https://github.com/Rookeys/balance-game-back/issues/8

## PR 유형
- [ ] 버그 수정
- [ ] 새로운 기능 추가
- [ ] 사용자 UI 디자인 변경
- [x] 코드 리팩토링
- [ ] 테스트 추가
- [ ] 기타 (내용을 적어주세요) :

## PR 체크리스트
- [x] 로컬 빌드가 정상적으로 실행되었습니다.
- [x] PR 작업에 대한 테스트를 완료하였습니다.