### PR TITLE
썸네일 DTO 에 실리는 미디어 타입이 항상 두 번째 썸네일의 타입으로 매핑되는 버그 해결.

### DIFF
--- a/src/main/java/com/games/balancegameback/dto/game/GameListSelectionResponse.java
+++ b/src/main/java/com/games/balancegameback/dto/game/GameListSelectionResponse.java
@@ -13,6 +13,9 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class GameListSelectionResponse {
 
+    @Schema(description = "리소스 ID")
+    private Long id;
+
     @Schema(description = "선택지 타이틀")
     private String title;
 

--- a/src/main/java/com/games/balancegameback/infra/repository/game/impl/GameListRepositoryImpl.java
+++ b/src/main/java/com/games/balancegameback/infra/repository/game/impl/GameListRepositoryImpl.java
@@ -70,6 +70,7 @@ public class GameListRepositoryImpl implements GameListRepository {
             }
 
             List<Tuple> tuples = jpaQueryFactory.select(
+                            resources.id,
                             resources.images.fileUrl.coalesce(resources.links.urls),
                             resources.images.mediaType.coalesce(resources.links.mediaType),
                             resources.title
@@ -84,16 +85,18 @@ public class GameListRepositoryImpl implements GameListRepository {
 
             GameListSelectionResponse leftSelection = (!tuples.isEmpty()) ?
                     GameListSelectionResponse.builder()
+                            .id(tuples.getFirst().get(resources.id))
                             .title(tuples.getFirst().get(resources.title))
-                            .type(tuples.get(1).get(resources.images.mediaType.coalesce(resources.links.mediaType)))
+                            .type(tuples.getFirst().get(resources.images.mediaType.coalesce(resources.links.mediaType)))
                             .content(tuples.getFirst().get(resources.images.fileUrl.coalesce(resources.links.urls)))
                             .build()
                     : null;
 
             GameListSelectionResponse rightSelection = (!tuples.isEmpty()) ?
                     GameListSelectionResponse.builder()
+                            .id(tuples.getLast().get(resources.id))
                             .title(tuples.getLast().get(resources.title))
-                            .type(tuples.get(1).get(resources.images.mediaType.coalesce(resources.links.mediaType)))
+                            .type(tuples.getLast().get(resources.images.mediaType.coalesce(resources.links.mediaType)))
                             .content(tuples.getLast().get(resources.images.fileUrl.coalesce(resources.links.urls)))
                             .build()
                     : null;

--- a/src/main/java/com/games/balancegameback/infra/repository/game/impl/GameRepositoryImpl.java
+++ b/src/main/java/com/games/balancegameback/infra/repository/game/impl/GameRepositoryImpl.java
@@ -99,6 +99,7 @@ public class GameRepositoryImpl implements GameRepository {
             Long totalPlayNums = tuple.get(results.id.count());
 
             List<Tuple> tuples = jpaQueryFactory.select(
+                            resources.id,
                             resources.images.fileUrl.coalesce(resources.links.urls),
                             resources.images.mediaType.coalesce(resources.links.mediaType),
                             resources.title
@@ -113,16 +114,18 @@ public class GameRepositoryImpl implements GameRepository {
 
             GameListSelectionResponse leftSelection = (!tuples.isEmpty()) ?
                     GameListSelectionResponse.builder()
+                            .id(tuples.getFirst().get(resources.id))
                             .title(tuples.getFirst().get(resources.title))
-                            .type(tuples.get(1).get(resources.images.mediaType.coalesce(resources.links.mediaType)))
+                            .type(tuples.getFirst().get(resources.images.mediaType.coalesce(resources.links.mediaType)))
                             .content(tuples.getFirst().get(resources.images.fileUrl.coalesce(resources.links.urls)))
                             .build()
                     : null;
 
             GameListSelectionResponse rightSelection = (!tuples.isEmpty()) ?
                     GameListSelectionResponse.builder()
+                            .id(tuples.getLast().get(resources.id))
                             .title(tuples.getLast().get(resources.title))
-                            .type(tuples.get(1).get(resources.images.mediaType.coalesce(resources.links.mediaType)))
+                            .type(tuples.getLast().get(resources.images.mediaType.coalesce(resources.links.mediaType)))
                             .content(tuples.getLast().get(resources.images.fileUrl.coalesce(resources.links.urls)))
                             .build()
                     : null;


### PR DESCRIPTION
## 작업내용 설명
- DB에서 썸네일 관련 정보를 받아오던 중 리스트에서 추출할 때 미디어 타입 부분만 같은 인덱스에서 가져오는 것을 확인.
- 이를 수정한 후 정상 동작함을 확인함.

## 관련 이슈
- https://github.com/Rookeys/balance-game-back/issues/35

## PR 유형
- [x] 버그 수정
- [ ] 새로운 기능 추가
- [ ] 사용자 UI 디자인 변경
- [ ] 코드 리팩토링
- [ ] 테스트 추가
- [ ] 기타 (내용을 적어주세요) :

## PR 체크리스트
- [x] 로컬 빌드가 정상적으로 실행되었습니다.
- [x] PR 작업에 대한 테스트를 완료하였습니다.