### PR TITLE
feat: Add logic to delete surplus data in disconnected S3. #8 #37

### DIFF
--- a/src/main/java/com/games/balancegameback/BalanceGameBackApplication.java
+++ b/src/main/java/com/games/balancegameback/BalanceGameBackApplication.java
@@ -7,7 +7,9 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableAsync;
 
+@EnableAsync
 @SpringBootApplication
 @EntityListeners(AuditingEntityListener.class)
 @EnableJpaAuditing

--- a/src/main/java/com/games/balancegameback/core/exception/ErrorCode.java
+++ b/src/main/java/com/games/balancegameback/core/exception/ErrorCode.java
@@ -23,6 +23,7 @@ public enum ErrorCode {
     KAKAO_ACCESS_TOKEN_FAILED(4001, "K4001", "Failed to get access token!"),
     KAKAO_USER_INFO_FAILED(4001, "K4002", "Failed to get user info!"),
     INVALID_TOKEN_EXCEPTION(4001, "4001", "Invalid JWT token"),
+    INVALID_IMAGE_EXCEPTION(4001, "4001_1", "Invalid S3 Image URL"),
     JWT_TOKEN_EXPIRED(4002, "4002", "JWT token has expired"),
     UNSUPPORTED_JWT_TOKEN(4003, "4003", "JWT token is unsupported"),
     EMPTY_JWT_CLAIMS( 4004, "4004", "JWT claims string is empty"),

--- a/src/main/java/com/games/balancegameback/service/game/impl/GameRoomService.java
+++ b/src/main/java/com/games/balancegameback/service/game/impl/GameRoomService.java
@@ -5,17 +5,21 @@ import com.games.balancegameback.core.exception.impl.BadRequestException;
 import com.games.balancegameback.core.exception.impl.UnAuthorizedException;
 import com.games.balancegameback.core.utils.CustomPageImpl;
 import com.games.balancegameback.domain.game.GameInviteCode;
+import com.games.balancegameback.domain.game.GameResources;
 import com.games.balancegameback.domain.game.Games;
 import com.games.balancegameback.domain.game.enums.AccessType;
 import com.games.balancegameback.domain.user.Users;
 import com.games.balancegameback.dto.game.*;
 import com.games.balancegameback.service.game.repository.GameRepository;
+import com.games.balancegameback.service.media.impl.S3Service;
 import com.games.balancegameback.service.user.impl.UserUtils;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -87,8 +91,8 @@ public class GameRoomService {
         Users users = userUtils.findUserByToken(request);
         this.existsHost(gameId, users);
 
+        gameRepository.deleteImagesInS3(gameId);    // 연관 관계가 끊어진 S3 내 사진 데이터를 삭제함.
         gameRepository.deleteById(gameId);
-        // 트리거에 해당 로직이 실행되었을 때 리소스들 중 연결되어 있는 방이 없으면 삭제하는 로직 추가 예정.
     }
 
     private void existsHost(Long gameId, Users users) {

--- a/src/main/java/com/games/balancegameback/service/game/repository/GameRepository.java
+++ b/src/main/java/com/games/balancegameback/service/game/repository/GameRepository.java
@@ -25,4 +25,6 @@ public interface GameRepository {
     void update(Games games);
 
     void deleteById(Long roomId);
+
+    void deleteImagesInS3(Long roomId);
 }

--- a/src/main/java/com/games/balancegameback/service/media/impl/S3Service.java
+++ b/src/main/java/com/games/balancegameback/service/media/impl/S3Service.java
@@ -1,0 +1,59 @@
+package com.games.balancegameback.service.media.impl;
+
+import com.games.balancegameback.core.exception.ErrorCode;
+import com.games.balancegameback.core.exception.impl.CustomJwtException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+
+    private final S3Client s3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    /**
+     * 이미지 URL에서 S3 key를 추출한 후, 해당 객체를 삭제함.
+     *
+     * @param imageUrl S3에 저장된 이미지의 URL
+     */
+    public void deleteImageByUrl(String imageUrl) {
+        try {
+            var url = URI.create(imageUrl).toURL();
+            var key = url.getPath();
+
+            if (key.startsWith("/image/")) {
+                key = key.substring(1);
+            }
+
+            var deleteRequest = DeleteObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(key)
+                    .build();
+
+            s3Client.deleteObject(deleteRequest);
+        } catch (MalformedURLException e) {
+            throw new CustomJwtException(ErrorCode.INVALID_IMAGE_EXCEPTION, "URL 형식이 올바르지 않습니다.");
+        }
+    }
+
+    /**
+     * 여러 이미지 URL에 대해 비동기 삭제 작업을 실행함.
+     *
+     * @param imageUrls 삭제할 이미지 URL 목록
+     */
+    @Async
+    public void deleteImagesAsync(List<String> imageUrls) {
+        imageUrls.forEach(this::deleteImageByUrl);
+    }
+}

--- a/src/main/java/com/games/balancegameback/service/user/impl/UserProfileService.java
+++ b/src/main/java/com/games/balancegameback/service/user/impl/UserProfileService.java
@@ -4,6 +4,7 @@ import com.games.balancegameback.domain.media.Images;
 import com.games.balancegameback.domain.user.Users;
 import com.games.balancegameback.dto.user.UserRequest;
 import com.games.balancegameback.dto.user.UserResponse;
+import com.games.balancegameback.service.media.impl.S3Service;
 import com.games.balancegameback.service.media.repository.ImageRepository;
 import com.games.balancegameback.service.user.UserRepository;
 import jakarta.servlet.http.HttpServletRequest;
@@ -15,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class UserProfileService {
 
+    private final S3Service s3Service;
     private final UserRepository userRepository;
     private final ImageRepository imageRepository;
     private final UserUtils userUtils;
@@ -43,9 +45,9 @@ public class UserProfileService {
             Images images = imageRepository.findByUsers(users);
 
             if (images != null) {   // 기존 프로필 사진이 존재할 시
+                s3Service.deleteImageByUrl(images.getFileUrl());
                 images.update(userRequest.getUrl());
                 imageRepository.update(images);
-                // 추후 연 끊긴 S3 내 사진 제거 로직 추가 예정.
             } else {                // 프로필 사진을 처음 등록할 시
                 images = Images.builder()
                         .fileUrl(userRequest.getUrl())


### PR DESCRIPTION
## 작업내용 설명
- 연결이 끊어진 S3 내 잉여 데이터들을 제거하는 로직을 추가함.

## 관련 이슈
- https://github.com/Rookeys/balance-game-back/issues/37

## PR 유형
- [ ] 버그 수정
- [x] 새로운 기능 추가
- [ ] 사용자 UI 디자인 변경
- [ ] 코드 리팩토링
- [ ] 테스트 추가
- [ ] 기타 (내용을 적어주세요) :

## PR 체크리스트
- [x] 로컬 빌드가 정상적으로 실행되었습니다.
- [x] PR 작업에 대한 테스트를 완료하였습니다.