### PR TITLE
메인 페이지 중복 값 처리 및 카테고리 파라미터 추가 

### DIFF
--- a/src/main/java/com/games/balancegameback/domain/game/enums/Category.java
+++ b/src/main/java/com/games/balancegameback/domain/game/enums/Category.java
@@ -2,5 +2,5 @@ package com.games.balancegameback.domain.game.enums;
 
 public enum Category {
     // 추후 데이터를 받으면 추가 예정 (써놓은 것들은 예시)
-    FUN, HORROR, HOT
+    FUN, HORROR, ACTION
 }

--- a/src/main/java/com/games/balancegameback/domain/game/enums/GameSortType.java
+++ b/src/main/java/com/games/balancegameback/domain/game/enums/GameSortType.java
@@ -1,5 +1,5 @@
 package com.games.balancegameback.domain.game.enums;
 
 public enum GameSortType {
-    idAsc, idDesc, playDesc, week, month
+    old, recent, playDesc, week, month
 }

--- a/src/main/java/com/games/balancegameback/dto/game/GameSearchRequest.java
+++ b/src/main/java/com/games/balancegameback/dto/game/GameSearchRequest.java
@@ -1,5 +1,6 @@
 package com.games.balancegameback.dto.game;
 
+import com.games.balancegameback.domain.game.enums.Category;
 import com.games.balancegameback.domain.game.enums.GameSortType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
@@ -16,7 +17,11 @@ public class GameSearchRequest {
     @Schema(description = "검색하려는 타이틀", example = "포메")
     private String title;
 
-    @Schema(description = "정렬 옵션", allowableValues = {"idAsc", "idDesc", "playDesc", "week"},
+    @Schema(description = "정렬 옵션", allowableValues = {"old", "recent", "playDesc", "week"},
             example = "playDesc")
-    private GameSortType sortType = GameSortType.idDesc;
+    private GameSortType sortType = GameSortType.recent;
+
+    @Schema(description = "카테고리", allowableValues = {"FUN", "HORROR", "ACTION"},
+            example = "FUN")
+    private Category category;
 }

--- a/src/main/java/com/games/balancegameback/infra/repository/game/impl/GameListRepositoryImpl.java
+++ b/src/main/java/com/games/balancegameback/infra/repository/game/impl/GameListRepositoryImpl.java
@@ -148,16 +148,16 @@ public class GameListRepositoryImpl implements GameListRepository {
                 .having(games.gameResources.size().goe(2))
                 .fetchOne();
 
-        return new CustomPageImpl<>(resultList, pageable, totalElements, cursorId, hasNext);
+        return new CustomPageImpl<>(resultList, pageable, totalElements != null ? totalElements : 0L, cursorId, hasNext);
     }
 
     private void setOptions(BooleanBuilder builder, BooleanBuilder totalBuilder, Long cursorId,
                             GameSearchRequest request, QGamesEntity games, QGameResultsEntity results) {
-        if (cursorId != null && request.getSortType().equals(GameSortType.idAsc)) {
+        if (cursorId != null && request.getSortType().equals(GameSortType.old)) {
             builder.and(games.id.gt(cursorId));
         }
 
-        if (cursorId != null && request.getSortType().equals(GameSortType.idDesc)) {
+        if (cursorId != null && request.getSortType().equals(GameSortType.recent)) {
             builder.and(games.id.lt(cursorId));
         }
 
@@ -171,6 +171,11 @@ public class GameListRepositoryImpl implements GameListRepository {
             totalBuilder.and(results.createdDate.isNull().or(results.createdDate.after(OffsetDateTime.now().minusMonths(1))));
         }
 
+        if (request.getCategory() != null) {
+            builder.and(games.category.eq(request.getCategory()));
+            totalBuilder.and(games.category.eq(request.getCategory()));
+        }
+
         if (request.getTitle() != null && !request.getTitle().isEmpty()) {
             builder.and(games.title.containsIgnoreCase(request.getTitle()));
             totalBuilder.and(games.title.containsIgnoreCase(request.getTitle()));
@@ -182,7 +187,7 @@ public class GameListRepositoryImpl implements GameListRepository {
         QGamesEntity games = QGamesEntity.gamesEntity;
 
         return switch (sortType) {
-            case idAsc -> games.id.asc();
+            case old -> games.id.asc();
             case week, month, playDesc -> games.gamePlayList.size().desc();
             default -> games.id.desc();
         };

--- a/src/main/java/com/games/balancegameback/infra/repository/game/impl/GameListRepositoryImpl.java
+++ b/src/main/java/com/games/balancegameback/infra/repository/game/impl/GameListRepositoryImpl.java
@@ -140,7 +140,7 @@ public class GameListRepositoryImpl implements GameListRepository {
         PaginationUtils.removeLastIfHasNext(resultList, pageable.getPageSize());
 
         Long totalElements = jpaQueryFactory
-                .select(games.count())
+                .select(games.id.countDistinct())
                 .from(games)
                 .leftJoin(results).on(results.gameResources.games.eq(games))
                 .where(totalBuilder)

--- a/src/main/java/com/games/balancegameback/web/game/GameListController.java
+++ b/src/main/java/com/games/balancegameback/web/game/GameListController.java
@@ -1,6 +1,7 @@
 package com.games.balancegameback.web.game;
 
 import com.games.balancegameback.core.utils.CustomPageImpl;
+import com.games.balancegameback.domain.game.enums.Category;
 import com.games.balancegameback.domain.game.enums.GameSortType;
 import com.games.balancegameback.dto.game.GameListResponse;
 import com.games.balancegameback.dto.game.GameSearchRequest;
@@ -40,15 +41,21 @@ public class GameListController {
             @Parameter(name = "title", description = "검색할 리소스 제목", example = "스페셜 아이템")
             @RequestParam(name = "title", required = false) String title,
 
+            @Parameter(name = "category", description = "카테고리",
+                    example = "FUN",
+                    schema = @Schema(allowableValues = {"FUN", "HORROR", "ACTION"}))
+            @RequestParam(name = "category", required = false) Category category,
+
             @Parameter(name = "sortType", description = "정렬 방식",
-                    example = "idDesc",
-                    schema = @Schema(allowableValues = {"week", "month", "playDesc", "idAsc", "idDesc"}))
-            @RequestParam(name = "sortType", required = false, defaultValue = "idDesc") GameSortType sortType) {
+                    example = "recent",
+                    schema = @Schema(allowableValues = {"week", "month", "playDesc", "old", "recent"}))
+            @RequestParam(name = "sortType", required = false, defaultValue = "recent") GameSortType sortType) {
 
         Pageable pageable = PageRequest.of(0, size);
         GameSearchRequest searchRequest = GameSearchRequest.builder()
                 .title(title)
                 .sortType(sortType)
+                .category(category)
                 .build();
 
         return gameService.getMainGameList(cursorId, pageable, searchRequest);

--- a/src/main/java/com/games/balancegameback/web/game/GameListController.java
+++ b/src/main/java/com/games/balancegameback/web/game/GameListController.java
@@ -29,7 +29,7 @@ public class GameListController {
             @ApiResponse(responseCode = "200", description = "발급 완료")
     })
     @GetMapping(value = "/list")
-    public CustomPageImpl<GameListResponse> getResources(
+    public CustomPageImpl<GameListResponse> getMainGameList(
 
             @Parameter(name = "cursorId", description = "커서 ID (페이징 처리용)", example = "15")
             @RequestParam(name = "cursorId", required = false) Long cursorId,

--- a/src/main/java/com/games/balancegameback/web/user/UserProfileController.java
+++ b/src/main/java/com/games/balancegameback/web/user/UserProfileController.java
@@ -1,6 +1,7 @@
 package com.games.balancegameback.web.user;
 
 import com.games.balancegameback.core.utils.CustomPageImpl;
+import com.games.balancegameback.domain.game.enums.Category;
 import com.games.balancegameback.domain.game.enums.GameSortType;
 import com.games.balancegameback.dto.game.GameListResponse;
 import com.games.balancegameback.dto.game.GameSearchRequest;
@@ -72,10 +73,15 @@ public class UserProfileController {
             @Parameter(name = "title", description = "검색할 리소스 제목", example = "포메")
             @RequestParam(name = "title", required = false) String title,
 
+            @Parameter(name = "category", description = "카테고리",
+                    example = "FUN",
+                    schema = @Schema(allowableValues = {"FUN", "HORROR", "ACTION"}))
+            @RequestParam(name = "category", required = false) Category category,
+
             @Parameter(name = "sortType", description = "정렬 방식",
-                    example = "idDesc",
-                    schema = @Schema(allowableValues = {"idAsc", "idDesc"}))
-            @RequestParam(name = "sortType", required = false, defaultValue = "idDesc") GameSortType sortType,
+                    example = "recent",
+                    schema = @Schema(allowableValues = {"old", "recent"}))
+            @RequestParam(name = "sortType", required = false, defaultValue = "recent") GameSortType sortType,
 
             HttpServletRequest request) {
 
@@ -83,6 +89,7 @@ public class UserProfileController {
         GameSearchRequest searchRequest = GameSearchRequest.builder()
                 .title(title)
                 .sortType(sortType)
+                .category(category)
                 .build();
 
         return gameService.getMyGameList(pageable, cursorId, searchRequest, request);


### PR DESCRIPTION
## 작업내용 설명
- 메인 페이지에서 데이터가 중복되는 부분이 발견돼 Distinct 로 해결함.
- 카테고리 파라미터 검색 기능을 추가함.

## 관련 이슈
- https://github.com/Rookeys/balance-game-back/issues/8

## PR 유형
- [x] 버그 수정
- [x] 새로운 기능 추가
- [ ] 사용자 UI 디자인 변경
- [x] 코드 리팩토링
- [ ] 테스트 추가
- [ ] 기타 (내용을 적어주세요) :

## PR 체크리스트
- [x] 로컬 빌드가 정상적으로 실행되었습니다.
- [x] PR 작업에 대한 테스트를 완료하였습니다.