### PR TITLE
메인 페이지 내 게임 상세보기 기능 추가 및 기존 API 경로 수정

### DIFF
--- a/src/main/java/com/games/balancegameback/core/config/SecurityConfig.java
+++ b/src/main/java/com/games/balancegameback/core/config/SecurityConfig.java
@@ -51,6 +51,7 @@ public class SecurityConfig {
                             .requestMatchers(HttpMethod.GET, "/api/v1/games/{gameId}/results/comments").permitAll()
                             .requestMatchers(HttpMethod.GET, "/api/v1/games/list").permitAll()
                             .requestMatchers(HttpMethod.GET, "/api/v1/games/categories").permitAll()
+                            .requestMatchers(HttpMethod.GET, "/api/v1/games/{gameId}").permitAll()
                             .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
                             .anyRequest().authenticated(); // 그 외 모든 요청은 검증 필요
                 })

--- a/src/main/java/com/games/balancegameback/core/jwt/JwtAuthenticationTokenFilter.java
+++ b/src/main/java/com/games/balancegameback/core/jwt/JwtAuthenticationTokenFilter.java
@@ -33,7 +33,7 @@ public class JwtAuthenticationTokenFilter extends OncePerRequestFilter {
                     "/api/v1/games/{gameId}/play", "/api/v1/games/{gameId}/play/{playId}",
                     "/api/v1/games/resources/{resourceId}/comments", "/api/v1/games/{gameId}/results",
                     "/api/v1/games/{gameId}/results/comments", "/api/v1/games/{gameId}/resources/{resourceId}",
-                    "/api/v1/users/exists", "/api/v1/games/list", "/api/v1/games/categories"
+                    "/api/v1/users/exists", "/api/v1/games/list", "/api/v1/games/categories", "/api/v1/games/{gameId}"
             ),
             "POST", Set.of(
                     "/api/v1/users/login/kakao", "/api/v1/users/test/login", "/api/v1/users/login",

--- a/src/main/java/com/games/balancegameback/dto/game/GameDetailResponse.java
+++ b/src/main/java/com/games/balancegameback/dto/game/GameDetailResponse.java
@@ -1,0 +1,52 @@
+package com.games.balancegameback.dto.game;
+
+import com.games.balancegameback.domain.game.enums.Category;
+import com.games.balancegameback.dto.user.UserMainResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class GameDetailResponse {
+
+    @Schema(description = "게임 타이틀")
+    private String title;
+
+    @Schema(description = "설명")
+    private String description;
+
+    @Schema(description = "썸네일 블라인드 여부")
+    private Boolean existsBlind;
+
+    @Schema(description = "카테고리", name = "categories")
+    private List<Category> categories;
+
+    @Schema(description = "총 플레이 횟수")
+    private int totalPlayNums;
+
+    @Schema(description = "총 리소스 갯수")
+    private int totalResourceNums;
+
+    @Schema(description = "제작일")
+    private OffsetDateTime createdAt;
+
+    @Schema(description = "수정일")
+    private OffsetDateTime updatedAt;
+
+    @Schema(description = "유저 정보")
+    private UserMainResponse userResponse;
+
+    @Schema(description = "왼쪽 선택지")
+    private GameListSelectionResponse leftSelection;
+
+    @Schema(description = "오른쪽 선택지")
+    private GameListSelectionResponse rightSelection;
+}

--- a/src/main/java/com/games/balancegameback/dto/game/gameplay/GameInfoResponse.java
+++ b/src/main/java/com/games/balancegameback/dto/game/gameplay/GameInfoResponse.java
@@ -13,7 +13,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class GameInfoResponse {
 
-    @Schema(description = "리소스 제목")
+    @Schema(description = "게임 제목")
     private String title;
 
     @Schema(description = "설명")

--- a/src/main/java/com/games/balancegameback/service/game/GameService.java
+++ b/src/main/java/com/games/balancegameback/service/game/GameService.java
@@ -53,14 +53,19 @@ public class GameService {
         return gameListService.getCategoryNums(title);
     }
 
+    // 게임 설정값 반환
+    public GameDetailResponse getGameStatus(Long gameId) {
+        return gameListService.getGameStatus(gameId);
+    }
+
     // 게임방 생성
     public Long saveGame(GameRequest gameRequest, HttpServletRequest request) {
         return gameRoomService.saveGame(gameRequest, request);
     }
 
-    // 게임 설정값 반환
-    public GameResponse getGameStatus(Long gameId, HttpServletRequest request) {
-        return gameRoomService.getGameStatus(gameId, request);
+    // 내가 만든 게임방 설정값 반환
+    public GameResponse getMyGameStatus(Long gameId, HttpServletRequest request) {
+        return gameRoomService.getMyGameStatus(gameId, request);
     }
 
     // 내가 만든 게임들 리스트 반환

--- a/src/main/java/com/games/balancegameback/service/game/impl/GameListService.java
+++ b/src/main/java/com/games/balancegameback/service/game/impl/GameListService.java
@@ -1,9 +1,7 @@
 package com.games.balancegameback.service.game.impl;
 
 import com.games.balancegameback.core.utils.CustomPageImpl;
-import com.games.balancegameback.dto.game.GameCategoryNumsResponse;
-import com.games.balancegameback.dto.game.GameListResponse;
-import com.games.balancegameback.dto.game.GameSearchRequest;
+import com.games.balancegameback.dto.game.*;
 import com.games.balancegameback.service.game.repository.GameListRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -22,5 +20,9 @@ public class GameListService {
 
     public GameCategoryNumsResponse getCategoryNums(String title) {
         return gameListRepository.getCategoryCounts(title);
+    }
+
+    public GameDetailResponse getGameStatus(Long gameId) {
+        return gameListRepository.getGameStatus(gameId);
     }
 }

--- a/src/main/java/com/games/balancegameback/service/game/impl/GameRoomService.java
+++ b/src/main/java/com/games/balancegameback/service/game/impl/GameRoomService.java
@@ -60,7 +60,7 @@ public class GameRoomService {
         return games.getId();
     }
 
-    public GameResponse getGameStatus(Long gameId, HttpServletRequest request) {
+    public GameResponse getMyGameStatus(Long gameId, HttpServletRequest request) {
         Users users = userUtils.findUserByToken(request);
         this.existsHost(gameId, users);
 

--- a/src/main/java/com/games/balancegameback/service/game/repository/GameListRepository.java
+++ b/src/main/java/com/games/balancegameback/service/game/repository/GameListRepository.java
@@ -2,6 +2,7 @@ package com.games.balancegameback.service.game.repository;
 
 import com.games.balancegameback.core.utils.CustomPageImpl;
 import com.games.balancegameback.dto.game.GameCategoryNumsResponse;
+import com.games.balancegameback.dto.game.GameDetailResponse;
 import com.games.balancegameback.dto.game.GameListResponse;
 import com.games.balancegameback.dto.game.GameSearchRequest;
 import org.springframework.data.domain.Pageable;
@@ -11,4 +12,6 @@ public interface GameListRepository {
     CustomPageImpl<GameListResponse> getGameList(Long cursorId, Pageable pageable, GameSearchRequest searchRequest);
 
     GameCategoryNumsResponse getCategoryCounts(String title);
+
+    GameDetailResponse getGameStatus(Long gameId);
 }

--- a/src/main/java/com/games/balancegameback/web/game/GameListController.java
+++ b/src/main/java/com/games/balancegameback/web/game/GameListController.java
@@ -3,9 +3,7 @@ package com.games.balancegameback.web.game;
 import com.games.balancegameback.core.utils.CustomPageImpl;
 import com.games.balancegameback.domain.game.enums.Category;
 import com.games.balancegameback.domain.game.enums.GameSortType;
-import com.games.balancegameback.dto.game.GameCategoryNumsResponse;
-import com.games.balancegameback.dto.game.GameListResponse;
-import com.games.balancegameback.dto.game.GameSearchRequest;
+import com.games.balancegameback.dto.game.*;
 import com.games.balancegameback.service.game.GameService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -58,6 +56,18 @@ public class GameListController {
                 .build();
 
         return gameService.getMainGameList(cursorId, pageable, searchRequest);
+    }
+
+    @Operation(summary = "게임방 정보 확인 API", description = "특정 게임방의 정보를 확인함.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "게임방의 정보 확인 성공")
+    })
+    @GetMapping(value = "/{gameId}")
+    public GameDetailResponse getGameStatus(
+            @Parameter(name = "gameId", description = "게임방의 ID", required = true)
+            @PathVariable(name = "gameId") Long gameId) {
+
+        return gameService.getGameStatus(gameId);
     }
 
     @Operation(summary = "각 카테고리 별 게임 갯수 출력 API", description = "각 카테고리 별 게임 갯수를 출력한다.")

--- a/src/main/java/com/games/balancegameback/web/game/GameRoomController.java
+++ b/src/main/java/com/games/balancegameback/web/game/GameRoomController.java
@@ -38,21 +38,6 @@ public class GameRoomController {
         return ResponseEntity.status(HttpStatus.CREATED).body(id);
     }
 
-    @Operation(summary = "게임방 정보 확인 API", description = "특정 게임방의 설정을 확인함.")
-    @SecurityRequirement(name = "bearerAuth")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "게임방 설정 내역 발급 성공"),
-            @ApiResponse(responseCode = "401", description = "게임 주인이 아닙니다.")
-    })
-    @GetMapping(value = "/{gameId}")
-    public GameResponse getGameStatus(
-            @Parameter(name = "gameId", description = "게임방의 ID", required = true)
-            @PathVariable(name = "gameId") Long gameId,
-
-            HttpServletRequest request) {
-        return gameService.getGameStatus(gameId, request);
-    }
-
     @Operation(summary = "게임방 설정 업데이트 API", description = "게임방의 설정들을 변경 가능.")
     @SecurityRequirement(name = "bearerAuth")
     @ApiResponses(value = {

--- a/src/main/java/com/games/balancegameback/web/user/UserProfileController.java
+++ b/src/main/java/com/games/balancegameback/web/user/UserProfileController.java
@@ -4,6 +4,7 @@ import com.games.balancegameback.core.utils.CustomPageImpl;
 import com.games.balancegameback.domain.game.enums.Category;
 import com.games.balancegameback.domain.game.enums.GameSortType;
 import com.games.balancegameback.dto.game.GameListResponse;
+import com.games.balancegameback.dto.game.GameResponse;
 import com.games.balancegameback.dto.game.GameSearchRequest;
 import com.games.balancegameback.dto.user.UserRequest;
 import com.games.balancegameback.dto.user.UserResponse;
@@ -91,6 +92,21 @@ public class UserProfileController {
                 .build();
 
         return gameService.getMyGameList(pageable, cursorId, searchRequest, request);
+    }
+
+    @Operation(summary = "내가 만든 게임방 정보 확인 API", description = "내 게임방의 설정을 확인함.")
+    @SecurityRequirement(name = "bearerAuth")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "게임방 설정 내역 발급 성공"),
+            @ApiResponse(responseCode = "401", description = "게임 주인이 아닙니다.")
+    })
+    @GetMapping(value = "/games/{gameId}")
+    public GameResponse getMyGameStatus(
+            @Parameter(name = "gameId", description = "게임방의 ID", required = true)
+            @PathVariable(name = "gameId") Long gameId,
+
+            HttpServletRequest request) {
+        return gameService.getMyGameStatus(gameId, request);
     }
 }
 


### PR DESCRIPTION
## 작업내용 설명
- 기존 /api/v1/games/{gameId} API 를 /api/v1/users/games/{gameId} 로 수정.
- /api/v1/games/{gameId} 는 메인 페이지에서 게임을 선택했을 때 누구나 볼 수 있는 게임 소개 API 로 추가.

## 관련 이슈
- https://github.com/Rookeys/balance-game-back/issues/61

## PR 유형
- [ ] 버그 수정
- [ ] 새로운 기능 추가
- [ ] 사용자 UI 디자인 변경
- [x] 코드 리팩토링
- [ ] 테스트 추가
- [ ] 기타 (내용을 적어주세요) :

## PR 체크리스트
- [x] 로컬 빌드가 정상적으로 실행되었습니다.
- [x] PR 작업에 대한 테스트를 완료하였습니다.