### PR TITLE
게임 제작자 익명 여부에 따른 댓글 익명 처리 및 제작자 태그 추가

### DIFF
--- a/src/main/java/com/games/balancegameback/core/jwt/JwtAuthenticationTokenFilter.java
+++ b/src/main/java/com/games/balancegameback/core/jwt/JwtAuthenticationTokenFilter.java
@@ -32,6 +32,7 @@ public class JwtAuthenticationTokenFilter extends OncePerRequestFilter {
                     "/swagger-ui/**", "/v3/api-docs/**",
                     "/api/v1/games/{gameId}/play", "/api/v1/games/{gameId}/play/{playId}",
                     "/api/v1/games/resources/{resourceId}/comments", "/api/v1/games/{gameId}/results",
+                    "/api/v1/games/resources/{resourceId}/comments/{parentId}",
                     "/api/v1/games/{gameId}/results/comments", "/api/v1/games/{gameId}/resources/{resourceId}",
                     "/api/v1/users/exists", "/api/v1/games/list", "/api/v1/games/categories", "/api/v1/games/{gameId}"
             ),

--- a/src/main/java/com/games/balancegameback/dto/game/comment/GameResourceChildrenCommentResponse.java
+++ b/src/main/java/com/games/balancegameback/dto/game/comment/GameResourceChildrenCommentResponse.java
@@ -6,7 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 
 @Getter
 @Builder
@@ -24,14 +24,17 @@ public class GameResourceChildrenCommentResponse {
     private String nickname;
 
     @Schema(description = "작성 시간")
-    private LocalDateTime createdDateTime;
+    private OffsetDateTime createdDateTime;
 
     @Schema(description = "수정 시간")
-    private LocalDateTime updatedDateTime;
+    private OffsetDateTime updatedDateTime;
 
     @Schema(description = "좋아요 총합")
     private int like;
 
     @Schema(description = "좋아요 클릭 유무")
-    private boolean isLiked;
+    private boolean existsLiked;
+
+    @Schema(description = "작성자 본인 확인")
+    private boolean existsWriter;
 }

--- a/src/main/java/com/games/balancegameback/dto/game/comment/GameResourceCommentRequest.java
+++ b/src/main/java/com/games/balancegameback/dto/game/comment/GameResourceCommentRequest.java
@@ -10,7 +10,6 @@ import lombok.NoArgsConstructor;
 public class GameResourceCommentRequest {
 
     @Schema(description = "부모 댓글 Id")
-    @NotBlank(message = "부모 댓글의 ID는 필수입니다.")
     private Long parentId;
 
     @Schema(description = "댓글")

--- a/src/main/java/com/games/balancegameback/dto/game/comment/GameResourceParentCommentResponse.java
+++ b/src/main/java/com/games/balancegameback/dto/game/comment/GameResourceParentCommentResponse.java
@@ -6,7 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 
 @Getter
 @Builder
@@ -27,10 +27,10 @@ public class GameResourceParentCommentResponse {
     private int children;
 
     @Schema(description = "작성 시간")
-    private LocalDateTime createdDateTime;
+    private OffsetDateTime createdDateTime;
 
     @Schema(description = "수정 시간")
-    private LocalDateTime updatedDateTime;
+    private OffsetDateTime updatedDateTime;
 
     @Schema(description = "삭제 여부")
     private boolean isDeleted;
@@ -39,5 +39,8 @@ public class GameResourceParentCommentResponse {
     private int like;
 
     @Schema(description = "좋아요 클릭 유무")
-    private boolean isLiked;
+    private boolean existsLiked;
+
+    @Schema(description = "작성자 본인 확인")
+    private boolean existsWriter;
 }

--- a/src/main/java/com/games/balancegameback/dto/game/comment/GameResultCommentResponse.java
+++ b/src/main/java/com/games/balancegameback/dto/game/comment/GameResultCommentResponse.java
@@ -6,7 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 
 @Getter
 @Builder
@@ -24,14 +24,17 @@ public class GameResultCommentResponse {
     private String nickname;
 
     @Schema(description = "작성 시간")
-    private LocalDateTime createdDateTime;
+    private OffsetDateTime createdDateTime;
 
     @Schema(description = "수정 시간")
-    private LocalDateTime updatedDateTime;
+    private OffsetDateTime updatedDateTime;
 
     @Schema(description = "좋아요 총합")
     private int like;
 
     @Schema(description = "좋아요 클릭 유무")
-    private boolean isLiked;
+    private boolean existsLiked;
+
+    @Schema(description = "작성자 본인 확인")
+    private boolean existsWriter;
 }

--- a/src/main/java/com/games/balancegameback/service/game/impl/comment/GameResourceCommentService.java
+++ b/src/main/java/com/games/balancegameback/service/game/impl/comment/GameResourceCommentService.java
@@ -44,12 +44,13 @@ public class GameResourceCommentService {
     @Transactional
     public void addComment(Long resourceId, GameResourceCommentRequest commentRequest,
                            HttpServletRequest request) {
-        Users users = userUtils.findUserByToken(request);
-        GameResources gameResources = gameResourceRepository.findById(resourceId);
 
         if (commentsRepository.existsByResourceIdAndParentId(resourceId, commentRequest.getParentId())) {
             throw new BadRequestException("대댓글에 답글을 달 수 없습니다.", ErrorCode.RUNTIME_EXCEPTION);
         }
+
+        Users users = userUtils.findUserByToken(request);
+        GameResources gameResources = gameResourceRepository.findById(resourceId);
 
         GameResourceComments comments = GameResourceComments.builder()
                 .comment(commentRequest.getComment())


### PR DESCRIPTION
## 작업내용 설명
- 작성자가 자신의 게임에 댓글을 달았을 경우 제작자 태그를 띄울 수 있도록 추가함.
- 게임방 익명 설정 여부에 따라 작성자의 댓글 내역의 닉네임이 익명 처리가 되도록 변경함.
- 일부 쿼리를 리팩토링함.

## 관련 이슈
- https://github.com/Rookeys/balance-game-back/issues/63


## PR 유형
- [ ] 버그 수정
- [x] 새로운 기능 추가
- [ ] 사용자 UI 디자인 변경
- [x] 코드 리팩토링
- [ ] 테스트 추가
- [ ] 기타 (내용을 적어주세요) :

## PR 체크리스트
- [x] 로컬 빌드가 정상적으로 실행되었습니다.
- [x] PR 작업에 대한 테스트를 완료하였습니다.