### PR TITLE
리소스 서비스 일부 API 기능 변경 및 추가

### DIFF
--- a/src/main/java/com/games/balancegameback/core/config/SecurityConfig.java
+++ b/src/main/java/com/games/balancegameback/core/config/SecurityConfig.java
@@ -52,6 +52,7 @@ public class SecurityConfig {
                             .requestMatchers(HttpMethod.GET, "/api/v1/games/list").permitAll()
                             .requestMatchers(HttpMethod.GET, "/api/v1/games/categories").permitAll()
                             .requestMatchers(HttpMethod.GET, "/api/v1/games/{gameId}").permitAll()
+                            .requestMatchers(HttpMethod.GET, "/api/v1/games/{gameId}/resources/count").permitAll()
                             .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
                             .anyRequest().authenticated(); // 그 외 모든 요청은 검증 필요
                 })

--- a/src/main/java/com/games/balancegameback/core/jwt/JwtAuthenticationTokenFilter.java
+++ b/src/main/java/com/games/balancegameback/core/jwt/JwtAuthenticationTokenFilter.java
@@ -34,7 +34,8 @@ public class JwtAuthenticationTokenFilter extends OncePerRequestFilter {
                     "/api/v1/games/resources/{resourceId}/comments", "/api/v1/games/{gameId}/results",
                     "/api/v1/games/resources/{resourceId}/comments/{parentId}",
                     "/api/v1/games/{gameId}/results/comments", "/api/v1/games/{gameId}/resources/{resourceId}",
-                    "/api/v1/users/exists", "/api/v1/games/list", "/api/v1/games/categories", "/api/v1/games/{gameId}"
+                    "/api/v1/games/{gameId}/resources/count", "/api/v1/users/exists", "/api/v1/games/list",
+                    "/api/v1/games/categories", "/api/v1/games/{gameId}"
             ),
             "POST", Set.of(
                     "/api/v1/users/login/kakao", "/api/v1/users/test/login", "/api/v1/users/login",

--- a/src/main/java/com/games/balancegameback/core/utils/CustomBasedPageImpl.java
+++ b/src/main/java/com/games/balancegameback/core/utils/CustomBasedPageImpl.java
@@ -1,0 +1,24 @@
+package com.games.balancegameback.core.utils;
+
+import lombok.Getter;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+@Getter
+public class CustomBasedPageImpl<T> extends PageImpl<T> {
+
+    private final boolean hasPrev;
+    private final boolean hasNext;
+
+    public CustomBasedPageImpl(List<T> content, Pageable pageable, long total) {
+        super(content, pageable, total);
+
+        int currentPage = pageable.getPageNumber();
+        int totalPages = (int) Math.ceil((double) total / pageable.getPageSize());
+
+        this.hasPrev = currentPage > 0;
+        this.hasNext = currentPage + 1 < totalPages;
+    }
+}

--- a/src/main/java/com/games/balancegameback/infra/repository/game/impl/GameResultCommentRepositoryImpl.java
+++ b/src/main/java/com/games/balancegameback/infra/repository/game/impl/GameResultCommentRepositoryImpl.java
@@ -58,7 +58,6 @@ public class GameResultCommentRepositoryImpl implements GameResultCommentReposit
                                                                               GameCommentSearchRequest searchRequest) {
         QGameResultCommentsEntity comments = QGameResultCommentsEntity.gameResultCommentsEntity;
         QGameCommentLikesEntity commentLikes = QGameCommentLikesEntity.gameCommentLikesEntity;
-        QGameResourcesEntity resources = QGameResourcesEntity.gameResourcesEntity;
         QGamesEntity games = QGamesEntity.gamesEntity;
         QUsersEntity user = QUsersEntity.usersEntity; // 댓글 작성자
         QUsersEntity gameUser = new QUsersEntity("gameUser"); // 게임 제작자

--- a/src/main/java/com/games/balancegameback/service/game/GameService.java
+++ b/src/main/java/com/games/balancegameback/service/game/GameService.java
@@ -2,6 +2,7 @@ package com.games.balancegameback.service.game;
 
 import com.games.balancegameback.core.exception.ErrorCode;
 import com.games.balancegameback.core.exception.impl.UnAuthorizedException;
+import com.games.balancegameback.core.utils.CustomBasedPageImpl;
 import com.games.balancegameback.core.utils.CustomPageImpl;
 import com.games.balancegameback.domain.game.Games;
 import com.games.balancegameback.domain.game.enums.CommentType;
@@ -105,12 +106,20 @@ public class GameService {
         return gameResourceService.getResource(gameId, resourceId);
     }
 
-    // 등록된 리소스 목록을 반환
+    // 등록된 리소스 목록을 반환 (CursorId)
     public CustomPageImpl<GameResourceResponse> getResources(Long gameId, Long cursorId, Pageable pageable,
                                                    GameResourceSearchRequest gameResourceSearchRequest,
                                                    HttpServletRequest request) {
         this.validateRequest(gameId, request);
         return gameResourceService.getResources(gameId, cursorId, pageable, gameResourceSearchRequest);
+    }
+
+    // 등록된 리소스 목록을 반환 (Page)
+    public CustomBasedPageImpl<GameResourceResponse> getResourcesUsingPage(Long gameId, Pageable pageable,
+                                                                           GameResourceSearchRequest gameResourceSearchRequest,
+                                                                           HttpServletRequest request) {
+        this.validateRequest(gameId, request);
+        return gameResourceService.getResourcesUsingPage(gameId, pageable, gameResourceSearchRequest);
     }
 
     // 등록한 리소스의 정보를 수정함

--- a/src/main/java/com/games/balancegameback/service/game/GameService.java
+++ b/src/main/java/com/games/balancegameback/service/game/GameService.java
@@ -63,6 +63,11 @@ public class GameService {
         return gameRoomService.saveGame(gameRequest, request);
     }
 
+    // 해당 게임방 내 리소스 총 갯수 반환
+    public Integer getCountResourcesInGames(Long gameId) {
+        return gameResourceService.getCountResourcesInGames(gameId);
+    }
+
     // 내가 만든 게임방 설정값 반환
     public GameResponse getMyGameStatus(Long gameId, HttpServletRequest request) {
         return gameRoomService.getMyGameStatus(gameId, request);

--- a/src/main/java/com/games/balancegameback/service/game/impl/GameResourceService.java
+++ b/src/main/java/com/games/balancegameback/service/game/impl/GameResourceService.java
@@ -1,5 +1,6 @@
 package com.games.balancegameback.service.game.impl;
 
+import com.games.balancegameback.core.utils.CustomBasedPageImpl;
 import com.games.balancegameback.core.utils.CustomPageImpl;
 import com.games.balancegameback.domain.game.GameResources;
 import com.games.balancegameback.domain.game.Games;
@@ -62,6 +63,11 @@ public class GameResourceService {
     public CustomPageImpl<GameResourceResponse> getResources(Long gameId, Long cursorId, Pageable pageable,
                                                              GameResourceSearchRequest request) {
         return gameResourceRepository.findByGameId(gameId, cursorId, pageable, request);
+    }
+
+    public CustomBasedPageImpl<GameResourceResponse> getResourcesUsingPage(Long gameId, Pageable pageable,
+                                                                           GameResourceSearchRequest request) {
+        return gameResourceRepository.findByGameIdWithPaging(gameId, pageable, request);
     }
 
     @Transactional

--- a/src/main/java/com/games/balancegameback/service/game/impl/GameResourceService.java
+++ b/src/main/java/com/games/balancegameback/service/game/impl/GameResourceService.java
@@ -33,6 +33,10 @@ public class GameResourceService {
     private final ImageRepository imageRepository;
     private final LinkRepository linkRepository;
 
+    public Integer getCountResourcesInGames(Long gameId) {
+        return gameResourceRepository.countByGameId(gameId);
+    }
+
     public GameResourceResponse getResource(Long gameId, Long resourceId) {
         GameResources resources = gameResourceRepository.findById(resourceId);
         int totalNums = gameResultRepository.countByGameId(gameId);

--- a/src/main/java/com/games/balancegameback/service/game/repository/GameResourceRepository.java
+++ b/src/main/java/com/games/balancegameback/service/game/repository/GameResourceRepository.java
@@ -1,5 +1,6 @@
 package com.games.balancegameback.service.game.repository;
 
+import com.games.balancegameback.core.utils.CustomBasedPageImpl;
 import com.games.balancegameback.core.utils.CustomPageImpl;
 import com.games.balancegameback.domain.game.GameResources;
 import com.games.balancegameback.dto.game.GameResourceResponse;
@@ -21,6 +22,9 @@ public interface GameResourceRepository {
 
     CustomPageImpl<GameResourceResponse> findByGameId(Long gameId, Long cursorId, Pageable pageable,
                                                       GameResourceSearchRequest request);
+
+    CustomBasedPageImpl<GameResourceResponse> findByGameIdWithPaging(Long gameId, Pageable pageable,
+                                                                     GameResourceSearchRequest request);
 
     void update(GameResources gameResources);
 

--- a/src/main/java/com/games/balancegameback/web/game/GameResourceController.java
+++ b/src/main/java/com/games/balancegameback/web/game/GameResourceController.java
@@ -46,6 +46,19 @@ public class GameResourceController {
     }
 
 
+    @Operation(summary = "게임방 내 리소스 총 갯수 반환 API", description = "해당 게임방의 리소스 총 갯수를 반환함.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "리소스 총 갯수 반환 성공")
+    })
+    @GetMapping(value = "/{gameId}/resources/count")
+    public Integer getCountResourcesInGames(
+            @Parameter(name = "gameId", description = "게임방의 ID", required = true)
+            @PathVariable(name = "gameId") Long gameId) {
+
+        return gameService.getCountResourcesInGames(gameId);
+    }
+
+
     @Operation(summary = "게임 리소스 리스트 발급 API", description = "해당 게임방의 리소스 목록을 제공한다.")
     @SecurityRequirement(name = "bearerAuth")
     @ApiResponses(value = {

--- a/src/main/java/com/games/balancegameback/web/game/GameResourceController.java
+++ b/src/main/java/com/games/balancegameback/web/game/GameResourceController.java
@@ -1,5 +1,6 @@
 package com.games.balancegameback.web.game;
 
+import com.games.balancegameback.core.utils.CustomBasedPageImpl;
 import com.games.balancegameback.core.utils.CustomPageImpl;
 import com.games.balancegameback.domain.game.enums.GameResourceSortType;
 import com.games.balancegameback.dto.game.GameResourceDeleteRequest;
@@ -15,6 +16,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -59,14 +61,14 @@ public class GameResourceController {
     }
 
 
-    @Operation(summary = "게임 리소스 리스트 발급 API", description = "해당 게임방의 리소스 목록을 제공한다.")
+    @Operation(summary = "게임 리소스 리스트 발급 API (CursorId)", description = "해당 게임방의 리소스 목록을 제공한다.")
     @SecurityRequirement(name = "bearerAuth")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "발급 완료"),
             @ApiResponse(responseCode = "401", description = "게임룸 호스트가 아닙니다.")
     })
     @GetMapping(value = "/{gameId}/resources")
-    public CustomPageImpl<GameResourceResponse> getResources(
+    public CustomPageImpl<GameResourceResponse> getResourcesUsingCursorId(
             @Parameter(name = "gameId", description = "게임방의 ID", required = true)
             @PathVariable(name = "gameId") Long gameId,
 
@@ -74,7 +76,7 @@ public class GameResourceController {
             @RequestParam(name = "cursorId", required = false) Long cursorId,
 
             @Parameter(name = "size", description = "한 페이지 당 출력 개수")
-            @RequestParam(name = "size", required = false, defaultValue = "15") int size,
+            @RequestParam(name = "size", required = false, defaultValue = "10") int size,
 
             @Parameter(name = "title", description = "검색할 리소스 제목")
             @RequestParam(name = "title", required = false) String title,
@@ -92,6 +94,42 @@ public class GameResourceController {
                 .build();
 
         return gameService.getResources(gameId, cursorId, pageable, searchRequest, request);
+    }
+
+    @Operation(summary = "게임 리소스 리스트 발급 API (Page)", description = "해당 게임방의 리소스 목록을 제공한다.")
+    @SecurityRequirement(name = "bearerAuth")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "발급 완료"),
+            @ApiResponse(responseCode = "401", description = "게임룸 호스트가 아닙니다.")
+    })
+    @GetMapping(value = "/{gameId}/resources/page")
+    public CustomBasedPageImpl<GameResourceResponse> getResourcesUsingPage(
+            @Parameter(name = "gameId", description = "게임방의 ID", required = true)
+            @PathVariable(name = "gameId") Long gameId,
+
+            @Parameter(name = "page", description = "페이지 넘버")
+            @RequestParam(name = "page", defaultValue = "1")
+            @Min(value = 1, message = "페이지 번호는 1 이상이어야 합니다.") int page,
+
+            @Parameter(name = "size", description = "한 페이지 당 출력 개수")
+            @RequestParam(name = "size", required = false, defaultValue = "10") int size,
+
+            @Parameter(name = "title", description = "검색할 리소스 제목")
+            @RequestParam(name = "title", required = false) String title,
+
+            @Parameter(name = "sortType", description = "정렬 방식",
+                    schema = @Schema(implementation = GameResourceSortType.class))
+            @RequestParam(name = "sortType", required = false, defaultValue = "RECENT") GameResourceSortType sortType,
+
+            HttpServletRequest request) {
+
+        Pageable pageable = PageRequest.of(page - 1, size);
+        GameResourceSearchRequest searchRequest = GameResourceSearchRequest.builder()
+                .title(title)
+                .sortType(sortType)
+                .build();
+
+        return gameService.getResourcesUsingPage(gameId, pageable, searchRequest, request);
     }
 
     @Operation(summary = "게임 리소스 수정 API", description = "리소스의 제목이나 URL 등을 수정할 수 있다.")

--- a/src/main/java/com/games/balancegameback/web/game/GameRoomController.java
+++ b/src/main/java/com/games/balancegameback/web/game/GameRoomController.java
@@ -1,7 +1,6 @@
 package com.games.balancegameback.web.game;
 
 import com.games.balancegameback.dto.game.GameRequest;
-import com.games.balancegameback.dto.game.GameResponse;
 import com.games.balancegameback.service.game.GameService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;


### PR DESCRIPTION
## 작업내용 설명
- 컨텐츠 업로드 페이지에서 현재 등록된 리소스의 총 갯수를 반환하는 API 추가
- 리소스 GET API 에서 page 로 동작하는 페이지네이션 API 를 분리 혹은 기존 API 에 추가

## 관련 이슈
- https://github.com/Rookeys/balance-game-back/issues/65

## PR 유형
- [ ] 버그 수정
- [x] 새로운 기능 추가
- [ ] 사용자 UI 디자인 변경
- [x] 코드 리팩토링
- [ ] 테스트 추가
- [ ] 기타 (내용을 적어주세요) :

## PR 체크리스트
- [x] 로컬 빌드가 정상적으로 실행되었습니다.
- [x] PR 작업에 대한 테스트를 완료하였습니다.