### PR TITLE
게임 서비스에서 발생한 몇몇 버그들 수정.

### DIFF
--- a/src/main/java/com/games/balancegameback/core/config/WebConfig.java
+++ b/src/main/java/com/games/balancegameback/core/config/WebConfig.java
@@ -26,6 +26,7 @@ public class WebConfig implements WebMvcConfigurer {
                 .allowedOrigins("http://localhost:3000",
                         "https://front.balancegame.site",
                         "https://balance-game-front-deploy.vercel.app",
+                        "https://zznpk.com",
                         "http://localhost:8888",
                         "https://api.balancegame.site")
                 .exposedHeaders("authorization", "refreshToken", "Set-Cookie")

--- a/src/main/java/com/games/balancegameback/dto/game/GameDetailResponse.java
+++ b/src/main/java/com/games/balancegameback/dto/game/GameDetailResponse.java
@@ -26,6 +26,9 @@ public class GameDetailResponse {
     @Schema(description = "썸네일 블라인드 여부")
     private Boolean existsBlind;
 
+    @Schema(description = "게임 제작자 본인 확인")
+    private boolean existsMine;
+
     @Schema(description = "카테고리", name = "categories")
     private List<Category> categories;
 

--- a/src/main/java/com/games/balancegameback/dto/game/comment/GameResourceChildrenCommentResponse.java
+++ b/src/main/java/com/games/balancegameback/dto/game/comment/GameResourceChildrenCommentResponse.java
@@ -40,4 +40,7 @@ public class GameResourceChildrenCommentResponse {
 
     @Schema(description = "작성자 본인 확인")
     private boolean existsWriter;
+
+    @Schema(description = "댓글 작성자 본인 확인")
+    private boolean existsMine;
 }

--- a/src/main/java/com/games/balancegameback/dto/game/comment/GameResourceParentCommentResponse.java
+++ b/src/main/java/com/games/balancegameback/dto/game/comment/GameResourceParentCommentResponse.java
@@ -46,4 +46,7 @@ public class GameResourceParentCommentResponse {
 
     @Schema(description = "작성자 본인 확인")
     private boolean existsWriter;
+
+    @Schema(description = "댓글 작성자 본인 확인")
+    private boolean existsMine;
 }

--- a/src/main/java/com/games/balancegameback/dto/game/comment/GameResultCommentResponse.java
+++ b/src/main/java/com/games/balancegameback/dto/game/comment/GameResultCommentResponse.java
@@ -40,4 +40,7 @@ public class GameResultCommentResponse {
 
     @Schema(description = "작성자 본인 확인")
     private boolean existsWriter;
+
+    @Schema(description = "댓글 작성자 본인 확인")
+    private boolean existsMine;
 }

--- a/src/main/java/com/games/balancegameback/infra/repository/game/impl/GameListRepositoryImpl.java
+++ b/src/main/java/com/games/balancegameback/infra/repository/game/impl/GameListRepositoryImpl.java
@@ -95,7 +95,7 @@ public class GameListRepositoryImpl implements GameListRepository {
         QLinksEntity links = QLinksEntity.linksEntity;
 
         BooleanExpression isMine = user != null ? users.uid.eq(user.getUid()) : Expressions.asBoolean(false);
-        Expression<Boolean> existsMineAlias = isMine.as("existsMine");
+        // Expression<Boolean> existsMineAlias = isMine.as("existsMine");
 
         Tuple tuple = jpaQueryFactory.selectDistinct(
                         games.id,
@@ -106,8 +106,8 @@ public class GameListRepositoryImpl implements GameListRepository {
                         games.isNamePrivate,
                         games.createdDate,
                         games.updatedDate,
-                        games.isBlind,
-                        existsMineAlias
+                        games.isBlind
+                        //existsMineAlias
                 ).from(games)
                 .leftJoin(results).on(results.gameResources.games.eq(games))
                 .leftJoin(games.gameResources, resources)
@@ -132,7 +132,7 @@ public class GameListRepositoryImpl implements GameListRepository {
         OffsetDateTime createdAt = tuple.get(games.createdDate);
         OffsetDateTime updatedAt = tuple.get(games.updatedDate);
         Boolean isBlind = tuple.get(games.isBlind);
-        Boolean existsMine = tuple.get(existsMineAlias);
+        //Boolean existsMine = tuple.get(existsMineAlias);
 
         if (isPrivate) {
             nickname = "익명";
@@ -201,7 +201,7 @@ public class GameListRepositoryImpl implements GameListRepository {
                 .description(description)
                 .categories(category)
                 .existsBlind(isBlind)
-                .existsMine(Boolean.TRUE.equals(existsMine))
+                //.existsMine(Boolean.TRUE.equals(existsMine))
                 .totalPlayNums(totalPlayNums != null ? totalPlayNums.intValue() : 0)
                 .totalResourceNums(totalResourceNums != null ? totalResourceNums.intValue() : 0)
                 .createdAt(createdAt)

--- a/src/main/java/com/games/balancegameback/infra/repository/game/impl/GameListRepositoryImpl.java
+++ b/src/main/java/com/games/balancegameback/infra/repository/game/impl/GameListRepositoryImpl.java
@@ -201,7 +201,7 @@ public class GameListRepositoryImpl implements GameListRepository {
                 .description(description)
                 .categories(category)
                 .existsBlind(isBlind)
-                .existsMine(existsMine)
+                .existsMine(Boolean.TRUE.equals(existsMine))
                 .totalPlayNums(totalPlayNums != null ? totalPlayNums.intValue() : 0)
                 .totalResourceNums(totalResourceNums != null ? totalResourceNums.intValue() : 0)
                 .createdAt(createdAt)

--- a/src/main/java/com/games/balancegameback/infra/repository/game/impl/GameListRepositoryImpl.java
+++ b/src/main/java/com/games/balancegameback/infra/repository/game/impl/GameListRepositoryImpl.java
@@ -154,6 +154,8 @@ public class GameListRepositoryImpl implements GameListRepository {
                         resources.id,
                         resources.images.fileUrl.coalesce(resources.links.urls),
                         resources.images.mediaType.coalesce(resources.links.mediaType),
+                        links.startSec.coalesce(0),
+                        links.endSec.coalesce(0),
                         resources.title
                 ).from(resources)
                 .leftJoin(resources.images, images)
@@ -169,6 +171,8 @@ public class GameListRepositoryImpl implements GameListRepository {
                         .title(tuples.getFirst().get(resources.title))
                         .type(tuples.getFirst().get(resources.images.mediaType.coalesce(resources.links.mediaType)))
                         .content(tuples.getFirst().get(resources.images.fileUrl.coalesce(resources.links.urls)))
+                        .startSec(Optional.ofNullable(tuples.getFirst().get(links.startSec.coalesce(0))).orElse(0))
+                        .endSec(Optional.ofNullable(tuples.getFirst().get(links.endSec.coalesce(0))).orElse(0))
                         .build()
                 : null;
 
@@ -178,6 +182,8 @@ public class GameListRepositoryImpl implements GameListRepository {
                         .title(tuples.getLast().get(resources.title))
                         .type(tuples.getLast().get(resources.images.mediaType.coalesce(resources.links.mediaType)))
                         .content(tuples.getLast().get(resources.images.fileUrl.coalesce(resources.links.urls)))
+                        .startSec(Optional.ofNullable(tuples.getLast().get(links.startSec.coalesce(0))).orElse(0))
+                        .endSec(Optional.ofNullable(tuples.getLast().get(links.endSec.coalesce(0))).orElse(0))
                         .build()
                 : null;
 

--- a/src/main/java/com/games/balancegameback/infra/repository/game/impl/GameListRepositoryImpl.java
+++ b/src/main/java/com/games/balancegameback/infra/repository/game/impl/GameListRepositoryImpl.java
@@ -161,8 +161,8 @@ public class GameListRepositoryImpl implements GameListRepository {
 
         List<Tuple> tuples = jpaQueryFactory.select(
                         resources.id,
-                        resources.images.fileUrl.coalesce(resources.links.urls),
-                        resources.images.mediaType.coalesce(resources.links.mediaType),
+                        images.fileUrl.coalesce(links.urls),
+                        images.mediaType.coalesce(links.mediaType),
                         links.startSec.coalesce(0),
                         links.endSec.coalesce(0),
                         resources.title
@@ -178,8 +178,8 @@ public class GameListRepositoryImpl implements GameListRepository {
                 GameListSelectionResponse.builder()
                         .id(tuples.getFirst().get(resources.id))
                         .title(tuples.getFirst().get(resources.title))
-                        .type(tuples.getFirst().get(resources.images.mediaType.coalesce(resources.links.mediaType)))
-                        .content(tuples.getFirst().get(resources.images.fileUrl.coalesce(resources.links.urls)))
+                        .type(tuples.getFirst().get(images.mediaType.coalesce(links.mediaType)))
+                        .content(tuples.getFirst().get(images.fileUrl.coalesce(links.urls)))
                         .startSec(Optional.ofNullable(tuples.getFirst().get(links.startSec.coalesce(0))).orElse(0))
                         .endSec(Optional.ofNullable(tuples.getFirst().get(links.endSec.coalesce(0))).orElse(0))
                         .build()
@@ -189,8 +189,8 @@ public class GameListRepositoryImpl implements GameListRepository {
                 GameListSelectionResponse.builder()
                         .id(tuples.getLast().get(resources.id))
                         .title(tuples.getLast().get(resources.title))
-                        .type(tuples.getLast().get(resources.images.mediaType.coalesce(resources.links.mediaType)))
-                        .content(tuples.getLast().get(resources.images.fileUrl.coalesce(resources.links.urls)))
+                        .type(tuples.getLast().get(images.mediaType.coalesce(links.mediaType)))
+                        .content(tuples.getLast().get(images.fileUrl.coalesce(links.urls)))
                         .startSec(Optional.ofNullable(tuples.getLast().get(links.startSec.coalesce(0))).orElse(0))
                         .endSec(Optional.ofNullable(tuples.getLast().get(links.endSec.coalesce(0))).orElse(0))
                         .build()
@@ -271,8 +271,8 @@ public class GameListRepositoryImpl implements GameListRepository {
 
             List<Tuple> tuples = jpaQueryFactory.select(
                             resources.id,
-                            resources.images.fileUrl.coalesce(resources.links.urls),
-                            resources.images.mediaType.coalesce(resources.links.mediaType),
+                            images.fileUrl.coalesce(links.urls),
+                            images.mediaType.coalesce(links.mediaType),
                             links.startSec.coalesce(0),
                             links.endSec.coalesce(0),
                             resources.title
@@ -313,8 +313,8 @@ public class GameListRepositoryImpl implements GameListRepository {
                     GameListSelectionResponse.builder()
                             .id(tuples.getFirst().get(resources.id))
                             .title(tuples.getFirst().get(resources.title))
-                            .type(tuples.getFirst().get(resources.images.mediaType.coalesce(resources.links.mediaType)))
-                            .content(tuples.getFirst().get(resources.images.fileUrl.coalesce(resources.links.urls)))
+                            .type(tuples.getFirst().get(images.mediaType.coalesce(links.mediaType)))
+                            .content(tuples.getFirst().get(images.fileUrl.coalesce(links.urls)))
                             .startSec(Optional.ofNullable(tuples.getFirst().get(links.startSec.coalesce(0))).orElse(0))
                             .endSec(Optional.ofNullable(tuples.getFirst().get(links.endSec.coalesce(0))).orElse(0))
                             .build()
@@ -324,8 +324,8 @@ public class GameListRepositoryImpl implements GameListRepository {
                     GameListSelectionResponse.builder()
                             .id(tuples.getLast().get(resources.id))
                             .title(tuples.getLast().get(resources.title))
-                            .type(tuples.getLast().get(resources.images.mediaType.coalesce(resources.links.mediaType)))
-                            .content(tuples.getLast().get(resources.images.fileUrl.coalesce(resources.links.urls)))
+                            .type(tuples.getLast().get(images.mediaType.coalesce(links.mediaType)))
+                            .content(tuples.getLast().get(images.fileUrl.coalesce(links.urls)))
                             .startSec(Optional.ofNullable(tuples.getLast().get(links.startSec.coalesce(0))).orElse(0))
                             .endSec(Optional.ofNullable(tuples.getLast().get(links.endSec.coalesce(0))).orElse(0))
                             .build()

--- a/src/main/java/com/games/balancegameback/infra/repository/game/impl/GameListRepositoryImpl.java
+++ b/src/main/java/com/games/balancegameback/infra/repository/game/impl/GameListRepositoryImpl.java
@@ -12,6 +12,7 @@ import com.games.balancegameback.infra.entity.*;
 import com.games.balancegameback.service.game.repository.GameListRepository;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.Tuple;
+import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
@@ -93,7 +94,8 @@ public class GameListRepositoryImpl implements GameListRepository {
         QImagesEntity images = QImagesEntity.imagesEntity;
         QLinksEntity links = QLinksEntity.linksEntity;
 
-        BooleanExpression existsMineCondition = user != null ? users.uid.eq(user.getUid()) : Expressions.FALSE;
+        BooleanExpression isMine = user != null ? users.uid.eq(user.getUid()) : Expressions.asBoolean(false);
+        Expression<Boolean> existsMineAlias = isMine.as("existsMine");
 
         Tuple tuple = jpaQueryFactory.selectDistinct(
                         games.id,
@@ -105,7 +107,7 @@ public class GameListRepositoryImpl implements GameListRepository {
                         games.createdDate,
                         games.updatedDate,
                         games.isBlind,
-                        existsMineCondition
+                        existsMineAlias
                 ).from(games)
                 .leftJoin(results).on(results.gameResources.games.eq(games))
                 .leftJoin(games.gameResources, resources)
@@ -130,7 +132,7 @@ public class GameListRepositoryImpl implements GameListRepository {
         OffsetDateTime createdAt = tuple.get(games.createdDate);
         OffsetDateTime updatedAt = tuple.get(games.updatedDate);
         Boolean isBlind = tuple.get(games.isBlind);
-        Boolean existsMine = tuple.get(existsMineCondition);
+        Boolean existsMine = tuple.get(existsMineAlias);
 
         if (isPrivate) {
             nickname = "익명";

--- a/src/main/java/com/games/balancegameback/infra/repository/game/impl/GameRepositoryImpl.java
+++ b/src/main/java/com/games/balancegameback/infra/repository/game/impl/GameRepositoryImpl.java
@@ -206,18 +206,18 @@ public class GameRepositoryImpl implements GameRepository {
                 .from(games)
                 .leftJoin(games.gameResources, resources)
                 .leftJoin(games.categories, gameCategory)
-                .where(games.users.email.eq(users.getEmail()))
+                .where(games.users.uid.eq(users.getUid()))
                 .fetchOne();
 
         return new CustomPageImpl<>(resultList, pageable, totalElements != null ? totalElements : 0L, cursorId, hasNext);
     }
 
     @Override
-    public boolean existsIdAndUsersEmail(Long gameId, String email) {
+    public boolean existsIdAndUsers(Long gameId, Users users) {
         QGamesEntity games = QGamesEntity.gamesEntity;
 
         BooleanExpression condition = games.id.eq(gameId)
-                .and(games.users.email.eq(email));
+                .and(games.users.uid.eq(users.getUid()));
 
         Integer result = jpaQueryFactory
                 .selectOne()

--- a/src/main/java/com/games/balancegameback/infra/repository/game/impl/GameRepositoryImpl.java
+++ b/src/main/java/com/games/balancegameback/infra/repository/game/impl/GameRepositoryImpl.java
@@ -117,8 +117,8 @@ public class GameRepositoryImpl implements GameRepository {
 
             List<Tuple> tuples = jpaQueryFactory.select(
                             resources.id,
-                            resources.images.fileUrl.coalesce(resources.links.urls),
-                            resources.images.mediaType.coalesce(resources.links.mediaType),
+                            images.fileUrl.coalesce(links.urls),
+                            images.mediaType.coalesce(links.mediaType),
                             links.startSec.coalesce(0),
                             links.endSec.coalesce(0),
                             resources.title
@@ -159,10 +159,10 @@ public class GameRepositoryImpl implements GameRepository {
                     GameListSelectionResponse.builder()
                             .id(tuples.getFirst().get(resources.id))
                             .title(tuples.getFirst().get(resources.title))
-                            .type(tuples.getFirst().get(resources.images.mediaType.coalesce(resources.links.mediaType)))
+                            .type(tuples.getFirst().get(images.mediaType.coalesce(links.mediaType)))
                             .startSec(Optional.ofNullable(tuples.getFirst().get(links.startSec.coalesce(0))).orElse(0))
                             .endSec(Optional.ofNullable(tuples.getFirst().get(links.endSec.coalesce(0))).orElse(0))
-                            .content(tuples.getFirst().get(resources.images.fileUrl.coalesce(resources.links.urls)))
+                            .content(tuples.getFirst().get(images.fileUrl.coalesce(links.urls)))
                             .build()
                     : null;
 
@@ -170,10 +170,10 @@ public class GameRepositoryImpl implements GameRepository {
                     GameListSelectionResponse.builder()
                             .id(tuples.getLast().get(resources.id))
                             .title(tuples.getLast().get(resources.title))
-                            .type(tuples.getLast().get(resources.images.mediaType.coalesce(resources.links.mediaType)))
+                            .type(tuples.getLast().get(images.mediaType.coalesce(links.mediaType)))
                             .startSec(Optional.ofNullable(tuples.getLast().get(links.startSec.coalesce(0))).orElse(0))
                             .endSec(Optional.ofNullable(tuples.getLast().get(links.endSec.coalesce(0))).orElse(0))
-                            .content(tuples.getLast().get(resources.images.fileUrl.coalesce(resources.links.urls)))
+                            .content(tuples.getLast().get(images.fileUrl.coalesce(links.urls)))
                             .build()
                     : null;
 

--- a/src/main/java/com/games/balancegameback/infra/repository/game/impl/GameRepositoryImpl.java
+++ b/src/main/java/com/games/balancegameback/infra/repository/game/impl/GameRepositoryImpl.java
@@ -25,6 +25,7 @@ import org.springframework.stereotype.Repository;
 
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Repository
@@ -118,6 +119,8 @@ public class GameRepositoryImpl implements GameRepository {
                             resources.id,
                             resources.images.fileUrl.coalesce(resources.links.urls),
                             resources.images.mediaType.coalesce(resources.links.mediaType),
+                            links.startSec.coalesce(0),
+                            links.endSec.coalesce(0),
                             resources.title
                     ).from(resources)
                     .leftJoin(resources.images, images)
@@ -157,6 +160,8 @@ public class GameRepositoryImpl implements GameRepository {
                             .id(tuples.getFirst().get(resources.id))
                             .title(tuples.getFirst().get(resources.title))
                             .type(tuples.getFirst().get(resources.images.mediaType.coalesce(resources.links.mediaType)))
+                            .startSec(Optional.ofNullable(tuples.getFirst().get(links.startSec.coalesce(0))).orElse(0))
+                            .endSec(Optional.ofNullable(tuples.getFirst().get(links.endSec.coalesce(0))).orElse(0))
                             .content(tuples.getFirst().get(resources.images.fileUrl.coalesce(resources.links.urls)))
                             .build()
                     : null;
@@ -166,6 +171,8 @@ public class GameRepositoryImpl implements GameRepository {
                             .id(tuples.getLast().get(resources.id))
                             .title(tuples.getLast().get(resources.title))
                             .type(tuples.getLast().get(resources.images.mediaType.coalesce(resources.links.mediaType)))
+                            .startSec(Optional.ofNullable(tuples.getLast().get(links.startSec.coalesce(0))).orElse(0))
+                            .endSec(Optional.ofNullable(tuples.getLast().get(links.endSec.coalesce(0))).orElse(0))
                             .content(tuples.getLast().get(resources.images.fileUrl.coalesce(resources.links.urls)))
                             .build()
                     : null;

--- a/src/main/java/com/games/balancegameback/infra/repository/game/impl/GameResourceCommentRepositoryImpl.java
+++ b/src/main/java/com/games/balancegameback/infra/repository/game/impl/GameResourceCommentRepositoryImpl.java
@@ -120,9 +120,8 @@ public class GameResourceCommentRepositoryImpl implements GameResourceCommentRep
                         comments.likes.size().as("like"),
                         this.isLikedExpression(users).as("existsLiked"),
                         comments.users.uid.eq(gameUser.uid).as("existsWriter"),
-                        users != null && users.getUid() != null ?
-                                comments.users.uid.eq(users.getUid()).as("existsMine") :
-                                Expressions.asBoolean(false).as("existsMine")
+                        Expressions.booleanTemplate("{0} = {1}", comments.users.uid,
+                                users != null ? users.getUid() : "")
                 ))
                 .from(comments)
                 .leftJoin(comments.users, user)
@@ -212,9 +211,8 @@ public class GameResourceCommentRepositoryImpl implements GameResourceCommentRep
                         comments.likes.size().as("like"),
                         this.isLikedExpression(users).as("existsLiked"),
                         comments.users.uid.eq(gameUser.uid).as("existsWriter"),
-                        users != null && users.getUid() != null ?
-                                comments.users.uid.eq(users.getUid()).as("existsMine") :
-                                Expressions.asBoolean(false).as("existsMine")
+                        Expressions.booleanTemplate("{0} = {1}", comments.users.uid,
+                                users != null ? users.getUid() : "")
                 ))
                 .from(comments)
                 .leftJoin(comments.users, user)

--- a/src/main/java/com/games/balancegameback/infra/repository/game/impl/GameResourceCommentRepositoryImpl.java
+++ b/src/main/java/com/games/balancegameback/infra/repository/game/impl/GameResourceCommentRepositoryImpl.java
@@ -238,28 +238,6 @@ public class GameResourceCommentRepositoryImpl implements GameResourceCommentRep
     }
 
     @Override
-    public boolean existsByGameIdAndResourceIdAndCommentId(Long gameId, Long resourceId, Long commentId) {
-        QGameResourceCommentsEntity comments = QGameResourceCommentsEntity.gameResourceCommentsEntity;
-
-        BooleanExpression condition = comments.id.eq(commentId)
-                .and(comments.gameResources.id.eq(resourceId))
-                .and(comments.gameResources.games.id.eq(gameId));
-
-        Integer result = jpaQueryFactory
-                .selectOne()
-                .from(comments)
-                .where(condition)
-                .fetchFirst();
-
-        return result != null;
-    }
-
-    @Override
-    public boolean existsById(Long commentId) {
-        return gameResourceCommentRepository.existsById(commentId);
-    }
-
-    @Override
     public boolean isChildComment(Long parentId) {
         QGameResourceCommentsEntity comments = QGameResourceCommentsEntity.gameResourceCommentsEntity;
 

--- a/src/main/java/com/games/balancegameback/infra/repository/game/impl/GameResourceCommentRepositoryImpl.java
+++ b/src/main/java/com/games/balancegameback/infra/repository/game/impl/GameResourceCommentRepositoryImpl.java
@@ -120,8 +120,9 @@ public class GameResourceCommentRepositoryImpl implements GameResourceCommentRep
                         comments.likes.size().as("like"),
                         this.isLikedExpression(users).as("existsLiked"),
                         comments.users.uid.eq(gameUser.uid).as("existsWriter"),
-                        Expressions.booleanTemplate("{0} = {1}", comments.users.uid,
-                                users != null ? users.getUid() : "")
+                        Expressions.booleanTemplate("binary {0} = binary {1}",
+                                comments.users.uid, users != null ? users.getUid() : "")
+
                 ))
                 .from(comments)
                 .leftJoin(comments.users, user)
@@ -211,8 +212,9 @@ public class GameResourceCommentRepositoryImpl implements GameResourceCommentRep
                         comments.likes.size().as("like"),
                         this.isLikedExpression(users).as("existsLiked"),
                         comments.users.uid.eq(gameUser.uid).as("existsWriter"),
-                        Expressions.booleanTemplate("{0} = {1}", comments.users.uid,
-                                users != null ? users.getUid() : "")
+                        Expressions.booleanTemplate("binary {0} = binary {1}",
+                                comments.users.uid, users != null ? users.getUid() : "")
+
                 ))
                 .from(comments)
                 .leftJoin(comments.users, user)

--- a/src/main/java/com/games/balancegameback/infra/repository/game/impl/GameResourceCommentRepositoryImpl.java
+++ b/src/main/java/com/games/balancegameback/infra/repository/game/impl/GameResourceCommentRepositoryImpl.java
@@ -93,7 +93,7 @@ public class GameResourceCommentRepositoryImpl implements GameResourceCommentRep
 
         this.setOptions(builder, cursorId, request, comments);
 
-        BooleanExpression leftJoinCondition = users != null ? comments.users.email.eq(users.getEmail()) : Expressions.FALSE;
+        BooleanExpression leftJoinCondition = users != null ? comments.users.uid.eq(users.getUid()) : Expressions.FALSE;
 
         BooleanExpression isMine = users != null ? user.uid.eq(users.getUid()) : Expressions.asBoolean(false);
         Expression<Boolean> existsMineAlias = isMine.as("existsMine");
@@ -128,7 +128,7 @@ public class GameResourceCommentRepositoryImpl implements GameResourceCommentRep
                 ))
                 .from(comments)
                 .leftJoin(comments.users, user)
-                .leftJoin(images).on(images.users.email.eq(user.email))
+                .leftJoin(images).on(images.users.uid.eq(user.uid))
                 .leftJoin(comments.gameResources, resources)
                 .leftJoin(resources.games, games)
                 .leftJoin(games.users, gameUser)
@@ -189,7 +189,7 @@ public class GameResourceCommentRepositoryImpl implements GameResourceCommentRep
 
         this.setOptions(builder, cursorId, request, comments);
         // 비로그인 회원은 좋아요를 표시했는지 안했는지 모르기 때문에 조건 추가.
-        BooleanExpression leftJoinCondition = users != null ? comments.users.email.eq(users.getEmail()) : Expressions.FALSE;
+        BooleanExpression leftJoinCondition = users != null ? comments.users.uid.eq(users.getUid()) : Expressions.FALSE;
 
         BooleanExpression isMine = users != null ? user.uid.eq(users.getUid()) : Expressions.asBoolean(false);
         Expression<Boolean> existsMineAlias = isMine.as("existsMine");
@@ -222,7 +222,7 @@ public class GameResourceCommentRepositoryImpl implements GameResourceCommentRep
                 ))
                 .from(comments)
                 .leftJoin(comments.users, user)
-                .leftJoin(images).on(images.users.email.eq(user.email))
+                .leftJoin(images).on(images.users.uid.eq(user.uid))
                 .leftJoin(comments.gameResources, resources)
                 .leftJoin(resources.games, games)
                 .leftJoin(games.users, gameUser)
@@ -365,7 +365,7 @@ public class GameResourceCommentRepositoryImpl implements GameResourceCommentRep
         return users != null ? JPAExpressions.selectOne()
                 .from(commentLikes)
                 .where(commentLikes.resourceComments.id.eq(comments.id)
-                        .and(commentLikes.users.email.eq(users.getEmail())))
+                        .and(commentLikes.users.uid.eq(users.getUid())))
                 .exists()
                 : Expressions.asBoolean(false);
     }

--- a/src/main/java/com/games/balancegameback/infra/repository/game/impl/GameResourceCommentRepositoryImpl.java
+++ b/src/main/java/com/games/balancegameback/infra/repository/game/impl/GameResourceCommentRepositoryImpl.java
@@ -94,6 +94,11 @@ public class GameResourceCommentRepositoryImpl implements GameResourceCommentRep
         this.setOptions(builder, cursorId, request, comments);
 
         BooleanExpression leftJoinCondition = users != null ? comments.users.uid.eq(users.getUid()) : Expressions.FALSE;
+
+        String userUid = users != null ? users.getUid() : "";
+        Expression<Boolean> existsMineExpression = Expressions.booleanTemplate("{0} COLLATE utf8mb4_general_ci = {1} COLLATE utf8mb4_general_ci",
+                comments.users.uid, userUid);
+
         OrderSpecifier<?> orderSpecifier = this.getOrderSpecifier(request.getSortType());
 
         List<GameResourceParentCommentResponse> list = jpaQueryFactory
@@ -120,9 +125,7 @@ public class GameResourceCommentRepositoryImpl implements GameResourceCommentRep
                         comments.likes.size().as("like"),
                         this.isLikedExpression(users).as("existsLiked"),
                         comments.users.uid.eq(gameUser.uid).as("existsWriter"),
-                        Expressions.booleanTemplate("binary {0} = binary {1}",
-                                comments.users.uid, users != null ? users.getUid() : "")
-
+                        existsMineExpression
                 ))
                 .from(comments)
                 .leftJoin(comments.users, user)
@@ -188,6 +191,11 @@ public class GameResourceCommentRepositoryImpl implements GameResourceCommentRep
         this.setOptions(builder, cursorId, request, comments);
         // 비로그인 회원은 좋아요를 표시했는지 안했는지 모르기 때문에 조건 추가.
         BooleanExpression leftJoinCondition = users != null ? comments.users.uid.eq(users.getUid()) : Expressions.FALSE;
+
+        String userUid = users != null ? users.getUid() : "";
+        Expression<Boolean> existsMineExpression = Expressions.booleanTemplate("{0} COLLATE utf8mb4_general_ci = {1} COLLATE utf8mb4_general_ci",
+                comments.users.uid, userUid);
+
         OrderSpecifier<?> orderSpecifier = this.getOrderSpecifier(request.getSortType());
 
         List<GameResourceChildrenCommentResponse> list = jpaQueryFactory
@@ -212,8 +220,7 @@ public class GameResourceCommentRepositoryImpl implements GameResourceCommentRep
                         comments.likes.size().as("like"),
                         this.isLikedExpression(users).as("existsLiked"),
                         comments.users.uid.eq(gameUser.uid).as("existsWriter"),
-                        Expressions.booleanTemplate("binary {0} = binary {1}",
-                                comments.users.uid, users != null ? users.getUid() : "")
+                        existsMineExpression
 
                 ))
                 .from(comments)

--- a/src/main/java/com/games/balancegameback/infra/repository/game/impl/GameResourceCommentRepositoryImpl.java
+++ b/src/main/java/com/games/balancegameback/infra/repository/game/impl/GameResourceCommentRepositoryImpl.java
@@ -190,7 +190,7 @@ public class GameResourceCommentRepositoryImpl implements GameResourceCommentRep
         // 비로그인 회원은 좋아요를 표시했는지 안했는지 모르기 때문에 조건 추가.
         BooleanExpression leftJoinCondition = users != null ? comments.users.uid.eq(users.getUid()) : Expressions.FALSE;
 
-        BooleanExpression isMine = users != null ? user.uid.eq(users.getUid()) : Expressions.asBoolean(false);
+        BooleanExpression isMine = users != null ? Expressions.asBoolean(user.uid.eq(users.getUid())) : Expressions.asBoolean(false);
 
         OrderSpecifier<?> orderSpecifier = this.getOrderSpecifier(request.getSortType());
 

--- a/src/main/java/com/games/balancegameback/infra/repository/game/impl/GameResourceCommentRepositoryImpl.java
+++ b/src/main/java/com/games/balancegameback/infra/repository/game/impl/GameResourceCommentRepositoryImpl.java
@@ -93,6 +93,8 @@ public class GameResourceCommentRepositoryImpl implements GameResourceCommentRep
         this.setOptions(builder, cursorId, request, comments);
 
         BooleanExpression leftJoinCondition = users != null ? comments.users.email.eq(users.getEmail()) : Expressions.FALSE;
+        BooleanExpression existsMineCondition = users != null ? user.uid.eq(users.getUid()) : Expressions.FALSE;
+
         OrderSpecifier<?> orderSpecifier = this.getOrderSpecifier(request.getSortType());
 
         List<GameResourceParentCommentResponse> list = jpaQueryFactory
@@ -118,7 +120,8 @@ public class GameResourceCommentRepositoryImpl implements GameResourceCommentRep
                         comments.isDeleted.as("isDeleted"),
                         comments.likes.size().as("like"),
                         this.isLikedExpression(users).as("existsLiked"),
-                        comments.users.uid.eq(gameUser.uid).as("existsWriter")
+                        comments.users.uid.eq(gameUser.uid).as("existsWriter"),
+                        existsMineCondition.as("existsMine")
                 ))
                 .from(comments)
                 .leftJoin(comments.users, user)
@@ -184,6 +187,7 @@ public class GameResourceCommentRepositoryImpl implements GameResourceCommentRep
         this.setOptions(builder, cursorId, request, comments);
         // 비로그인 회원은 좋아요를 표시했는지 안했는지 모르기 때문에 조건 추가.
         BooleanExpression leftJoinCondition = users != null ? comments.users.email.eq(users.getEmail()) : Expressions.FALSE;
+        BooleanExpression existsMineCondition = users != null ? user.uid.eq(users.getUid()) : Expressions.FALSE;
 
         OrderSpecifier<?> orderSpecifier = this.getOrderSpecifier(request.getSortType());
 
@@ -208,7 +212,8 @@ public class GameResourceCommentRepositoryImpl implements GameResourceCommentRep
                         comments.updatedDate.as("updatedDateTime"),
                         comments.likes.size().as("like"),
                         this.isLikedExpression(users).as("existsLiked"),
-                        comments.users.uid.eq(gameUser.uid).as("existsWriter")
+                        comments.users.uid.eq(gameUser.uid).as("existsWriter"),
+                        existsMineCondition.as("existsMine")
                 ))
                 .from(comments)
                 .leftJoin(comments.users, user)

--- a/src/main/java/com/games/balancegameback/infra/repository/game/impl/GameResourceCommentRepositoryImpl.java
+++ b/src/main/java/com/games/balancegameback/infra/repository/game/impl/GameResourceCommentRepositoryImpl.java
@@ -94,9 +94,6 @@ public class GameResourceCommentRepositoryImpl implements GameResourceCommentRep
         this.setOptions(builder, cursorId, request, comments);
 
         BooleanExpression leftJoinCondition = users != null ? comments.users.uid.eq(users.getUid()) : Expressions.FALSE;
-
-        BooleanExpression isMine = users != null ? user.uid.eq(users.getUid()) : Expressions.asBoolean(false);
-
         OrderSpecifier<?> orderSpecifier = this.getOrderSpecifier(request.getSortType());
 
         List<GameResourceParentCommentResponse> list = jpaQueryFactory
@@ -123,7 +120,9 @@ public class GameResourceCommentRepositoryImpl implements GameResourceCommentRep
                         comments.likes.size().as("like"),
                         this.isLikedExpression(users).as("existsLiked"),
                         comments.users.uid.eq(gameUser.uid).as("existsWriter"),
-                        isMine.as("existsMine")
+                        users != null && users.getUid() != null ?
+                                comments.users.uid.eq(users.getUid()).as("existsMine") :
+                                Expressions.asBoolean(false).as("existsMine")
                 ))
                 .from(comments)
                 .leftJoin(comments.users, user)
@@ -189,9 +188,6 @@ public class GameResourceCommentRepositoryImpl implements GameResourceCommentRep
         this.setOptions(builder, cursorId, request, comments);
         // 비로그인 회원은 좋아요를 표시했는지 안했는지 모르기 때문에 조건 추가.
         BooleanExpression leftJoinCondition = users != null ? comments.users.uid.eq(users.getUid()) : Expressions.FALSE;
-
-        BooleanExpression isMine = users != null ? Expressions.asBoolean(user.uid.eq(users.getUid())) : Expressions.asBoolean(false);
-
         OrderSpecifier<?> orderSpecifier = this.getOrderSpecifier(request.getSortType());
 
         List<GameResourceChildrenCommentResponse> list = jpaQueryFactory
@@ -216,7 +212,9 @@ public class GameResourceCommentRepositoryImpl implements GameResourceCommentRep
                         comments.likes.size().as("like"),
                         this.isLikedExpression(users).as("existsLiked"),
                         comments.users.uid.eq(gameUser.uid).as("existsWriter"),
-                        isMine.as("existsMine")
+                        users != null && users.getUid() != null ?
+                                comments.users.uid.eq(users.getUid()).as("existsMine") :
+                                Expressions.asBoolean(false).as("existsMine")
                 ))
                 .from(comments)
                 .leftJoin(comments.users, user)

--- a/src/main/java/com/games/balancegameback/infra/repository/game/impl/GameResourceCommentRepositoryImpl.java
+++ b/src/main/java/com/games/balancegameback/infra/repository/game/impl/GameResourceCommentRepositoryImpl.java
@@ -13,6 +13,7 @@ import com.games.balancegameback.infra.entity.*;
 import com.games.balancegameback.infra.repository.game.GameResourceCommentJpaRepository;
 import com.games.balancegameback.service.game.repository.GameResourceCommentRepository;
 import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -93,7 +94,9 @@ public class GameResourceCommentRepositoryImpl implements GameResourceCommentRep
         this.setOptions(builder, cursorId, request, comments);
 
         BooleanExpression leftJoinCondition = users != null ? comments.users.email.eq(users.getEmail()) : Expressions.FALSE;
-        BooleanExpression existsMineCondition = users != null ? user.uid.eq(users.getUid()) : Expressions.FALSE;
+
+        BooleanExpression isMine = users != null ? user.uid.eq(users.getUid()) : Expressions.asBoolean(false);
+        Expression<Boolean> existsMineAlias = isMine.as("existsMine");
 
         OrderSpecifier<?> orderSpecifier = this.getOrderSpecifier(request.getSortType());
 
@@ -121,7 +124,7 @@ public class GameResourceCommentRepositoryImpl implements GameResourceCommentRep
                         comments.likes.size().as("like"),
                         this.isLikedExpression(users).as("existsLiked"),
                         comments.users.uid.eq(gameUser.uid).as("existsWriter"),
-                        existsMineCondition.as("existsMine")
+                        existsMineAlias
                 ))
                 .from(comments)
                 .leftJoin(comments.users, user)
@@ -187,7 +190,9 @@ public class GameResourceCommentRepositoryImpl implements GameResourceCommentRep
         this.setOptions(builder, cursorId, request, comments);
         // 비로그인 회원은 좋아요를 표시했는지 안했는지 모르기 때문에 조건 추가.
         BooleanExpression leftJoinCondition = users != null ? comments.users.email.eq(users.getEmail()) : Expressions.FALSE;
-        BooleanExpression existsMineCondition = users != null ? user.uid.eq(users.getUid()) : Expressions.FALSE;
+
+        BooleanExpression isMine = users != null ? user.uid.eq(users.getUid()) : Expressions.asBoolean(false);
+        Expression<Boolean> existsMineAlias = isMine.as("existsMine");
 
         OrderSpecifier<?> orderSpecifier = this.getOrderSpecifier(request.getSortType());
 
@@ -213,7 +218,7 @@ public class GameResourceCommentRepositoryImpl implements GameResourceCommentRep
                         comments.likes.size().as("like"),
                         this.isLikedExpression(users).as("existsLiked"),
                         comments.users.uid.eq(gameUser.uid).as("existsWriter"),
-                        existsMineCondition.as("existsMine")
+                        existsMineAlias
                 ))
                 .from(comments)
                 .leftJoin(comments.users, user)

--- a/src/main/java/com/games/balancegameback/infra/repository/game/impl/GameResourceCommentRepositoryImpl.java
+++ b/src/main/java/com/games/balancegameback/infra/repository/game/impl/GameResourceCommentRepositoryImpl.java
@@ -96,7 +96,6 @@ public class GameResourceCommentRepositoryImpl implements GameResourceCommentRep
         BooleanExpression leftJoinCondition = users != null ? comments.users.uid.eq(users.getUid()) : Expressions.FALSE;
 
         BooleanExpression isMine = users != null ? user.uid.eq(users.getUid()) : Expressions.asBoolean(false);
-        Expression<Boolean> existsMineAlias = isMine.as("existsMine");
 
         OrderSpecifier<?> orderSpecifier = this.getOrderSpecifier(request.getSortType());
 
@@ -124,7 +123,7 @@ public class GameResourceCommentRepositoryImpl implements GameResourceCommentRep
                         comments.likes.size().as("like"),
                         this.isLikedExpression(users).as("existsLiked"),
                         comments.users.uid.eq(gameUser.uid).as("existsWriter"),
-                        existsMineAlias
+                        isMine.as("existsMine")
                 ))
                 .from(comments)
                 .leftJoin(comments.users, user)
@@ -192,7 +191,6 @@ public class GameResourceCommentRepositoryImpl implements GameResourceCommentRep
         BooleanExpression leftJoinCondition = users != null ? comments.users.uid.eq(users.getUid()) : Expressions.FALSE;
 
         BooleanExpression isMine = users != null ? user.uid.eq(users.getUid()) : Expressions.asBoolean(false);
-        Expression<Boolean> existsMineAlias = isMine.as("existsMine");
 
         OrderSpecifier<?> orderSpecifier = this.getOrderSpecifier(request.getSortType());
 
@@ -218,7 +216,7 @@ public class GameResourceCommentRepositoryImpl implements GameResourceCommentRep
                         comments.likes.size().as("like"),
                         this.isLikedExpression(users).as("existsLiked"),
                         comments.users.uid.eq(gameUser.uid).as("existsWriter"),
-                        existsMineAlias
+                        isMine.as("existsMine")
                 ))
                 .from(comments)
                 .leftJoin(comments.users, user)

--- a/src/main/java/com/games/balancegameback/infra/repository/game/impl/GameResultCommentRepositoryImpl.java
+++ b/src/main/java/com/games/balancegameback/infra/repository/game/impl/GameResultCommentRepositoryImpl.java
@@ -69,6 +69,11 @@ public class GameResultCommentRepositoryImpl implements GameResultCommentReposit
         this.setOptions(builder, cursorId, searchRequest, comments);
         // 비로그인 회원은 좋아요를 표시했는지 안했는지 모르기 때문에 조건 추가.
         BooleanExpression leftJoinCondition = users != null ? comments.users.uid.eq(users.getUid()) : Expressions.FALSE;
+
+        String userUid = users != null ? users.getUid() : "";
+        Expression<Boolean> existsMineExpression = Expressions.booleanTemplate("{0} COLLATE utf8mb4_general_ci = {1} COLLATE utf8mb4_general_ci",
+                comments.users.uid, userUid);
+
         OrderSpecifier<?> orderSpecifier = this.getOrderSpecifier(searchRequest.getSortType());
 
         List<GameResultCommentResponse> list = jpaQueryFactory
@@ -93,9 +98,7 @@ public class GameResultCommentRepositoryImpl implements GameResultCommentReposit
                         comments.likes.size().as("like"),
                         this.isLikedExpression(users).as("existsLiked"),
                         comments.users.uid.eq(gameUser.uid).as("existsWriter"),
-                        Expressions.booleanTemplate("binary {0} = binary {1}",
-                                comments.users.uid, users != null ? users.getUid() : "")
-
+                        existsMineExpression
                 ))
                 .from(comments)
                 .leftJoin(comments.users, user)

--- a/src/main/java/com/games/balancegameback/infra/repository/game/impl/GameResultCommentRepositoryImpl.java
+++ b/src/main/java/com/games/balancegameback/infra/repository/game/impl/GameResultCommentRepositoryImpl.java
@@ -69,9 +69,6 @@ public class GameResultCommentRepositoryImpl implements GameResultCommentReposit
         this.setOptions(builder, cursorId, searchRequest, comments);
         // 비로그인 회원은 좋아요를 표시했는지 안했는지 모르기 때문에 조건 추가.
         BooleanExpression leftJoinCondition = users != null ? comments.users.uid.eq(users.getUid()) : Expressions.FALSE;
-
-        BooleanExpression isMine = users != null ? Expressions.asBoolean(user.uid.eq(users.getUid())) : Expressions.asBoolean(false);
-
         OrderSpecifier<?> orderSpecifier = this.getOrderSpecifier(searchRequest.getSortType());
 
         List<GameResultCommentResponse> list = jpaQueryFactory
@@ -96,7 +93,9 @@ public class GameResultCommentRepositoryImpl implements GameResultCommentReposit
                         comments.likes.size().as("like"),
                         this.isLikedExpression(users).as("existsLiked"),
                         comments.users.uid.eq(gameUser.uid).as("existsWriter"),
-                        isMine.as("existsMine")
+                        users != null && users.getUid() != null ?
+                                comments.users.uid.eq(users.getUid()).as("existsMine") :
+                                Expressions.asBoolean(false).as("existsMine")
                 ))
                 .from(comments)
                 .leftJoin(comments.users, user)

--- a/src/main/java/com/games/balancegameback/infra/repository/game/impl/GameResultCommentRepositoryImpl.java
+++ b/src/main/java/com/games/balancegameback/infra/repository/game/impl/GameResultCommentRepositoryImpl.java
@@ -71,7 +71,6 @@ public class GameResultCommentRepositoryImpl implements GameResultCommentReposit
         BooleanExpression leftJoinCondition = users != null ? comments.users.uid.eq(users.getUid()) : Expressions.FALSE;
 
         BooleanExpression isMine = users != null ? user.uid.eq(users.getUid()) : Expressions.asBoolean(false);
-        Expression<Boolean> existsMineAlias = isMine.as("existsMine");
 
         OrderSpecifier<?> orderSpecifier = this.getOrderSpecifier(searchRequest.getSortType());
 
@@ -97,7 +96,7 @@ public class GameResultCommentRepositoryImpl implements GameResultCommentReposit
                         comments.likes.size().as("like"),
                         this.isLikedExpression(users).as("existsLiked"),
                         comments.users.uid.eq(gameUser.uid).as("existsWriter"),
-                        existsMineAlias
+                        isMine.as("existsMine")
                 ))
                 .from(comments)
                 .leftJoin(comments.users, user)

--- a/src/main/java/com/games/balancegameback/infra/repository/game/impl/GameResultCommentRepositoryImpl.java
+++ b/src/main/java/com/games/balancegameback/infra/repository/game/impl/GameResultCommentRepositoryImpl.java
@@ -70,7 +70,7 @@ public class GameResultCommentRepositoryImpl implements GameResultCommentReposit
         // 비로그인 회원은 좋아요를 표시했는지 안했는지 모르기 때문에 조건 추가.
         BooleanExpression leftJoinCondition = users != null ? comments.users.uid.eq(users.getUid()) : Expressions.FALSE;
 
-        BooleanExpression isMine = users != null ? user.uid.eq(users.getUid()) : Expressions.asBoolean(false);
+        BooleanExpression isMine = users != null ? Expressions.asBoolean(user.uid.eq(users.getUid())) : Expressions.asBoolean(false);
 
         OrderSpecifier<?> orderSpecifier = this.getOrderSpecifier(searchRequest.getSortType());
 

--- a/src/main/java/com/games/balancegameback/infra/repository/game/impl/GameResultCommentRepositoryImpl.java
+++ b/src/main/java/com/games/balancegameback/infra/repository/game/impl/GameResultCommentRepositoryImpl.java
@@ -68,7 +68,7 @@ public class GameResultCommentRepositoryImpl implements GameResultCommentReposit
 
         this.setOptions(builder, cursorId, searchRequest, comments);
         // 비로그인 회원은 좋아요를 표시했는지 안했는지 모르기 때문에 조건 추가.
-        BooleanExpression leftJoinCondition = users != null ? comments.users.email.eq(users.getEmail()) : Expressions.FALSE;
+        BooleanExpression leftJoinCondition = users != null ? comments.users.uid.eq(users.getUid()) : Expressions.FALSE;
 
         BooleanExpression isMine = users != null ? user.uid.eq(users.getUid()) : Expressions.asBoolean(false);
         Expression<Boolean> existsMineAlias = isMine.as("existsMine");
@@ -101,7 +101,7 @@ public class GameResultCommentRepositoryImpl implements GameResultCommentReposit
                 ))
                 .from(comments)
                 .leftJoin(comments.users, user)
-                .leftJoin(images).on(images.users.email.eq(user.email))
+                .leftJoin(images).on(images.users.uid.eq(user.uid))
                 .leftJoin(comments.games, games)
                 .leftJoin(games.users, gameUser)
                 .leftJoin(commentLikes).on(leftJoinCondition)
@@ -206,7 +206,7 @@ public class GameResultCommentRepositoryImpl implements GameResultCommentReposit
         return users != null ? JPAExpressions.selectOne()
                 .from(commentLikes)
                 .where(commentLikes.resultComments.id.eq(comments.id)
-                        .and(commentLikes.users.email.eq(users.getEmail())))
+                        .and(commentLikes.users.uid.eq(users.getUid())))
                 .exists()
                 : Expressions.asBoolean(false);
     }

--- a/src/main/java/com/games/balancegameback/infra/repository/game/impl/GameResultCommentRepositoryImpl.java
+++ b/src/main/java/com/games/balancegameback/infra/repository/game/impl/GameResultCommentRepositoryImpl.java
@@ -93,9 +93,8 @@ public class GameResultCommentRepositoryImpl implements GameResultCommentReposit
                         comments.likes.size().as("like"),
                         this.isLikedExpression(users).as("existsLiked"),
                         comments.users.uid.eq(gameUser.uid).as("existsWriter"),
-                        users != null && users.getUid() != null ?
-                                comments.users.uid.eq(users.getUid()).as("existsMine") :
-                                Expressions.asBoolean(false).as("existsMine")
+                        Expressions.booleanTemplate("{0} = {1}", comments.users.uid,
+                                users != null ? users.getUid() : "")
                 ))
                 .from(comments)
                 .leftJoin(comments.users, user)

--- a/src/main/java/com/games/balancegameback/infra/repository/game/impl/GameResultCommentRepositoryImpl.java
+++ b/src/main/java/com/games/balancegameback/infra/repository/game/impl/GameResultCommentRepositoryImpl.java
@@ -68,10 +68,10 @@ public class GameResultCommentRepositoryImpl implements GameResultCommentReposit
         this.setOptions(builder, cursorId, searchRequest, comments);
         // 비로그인 회원은 좋아요를 표시했는지 안했는지 모르기 때문에 조건 추가.
         BooleanExpression leftJoinCondition = users != null ? comments.users.email.eq(users.getEmail()) : Expressions.FALSE;
+        BooleanExpression existsMineCondition = users != null ? user.uid.eq(users.getUid()) : Expressions.FALSE;
 
         OrderSpecifier<?> orderSpecifier = this.getOrderSpecifier(searchRequest.getSortType());
 
-        assert users != null;
         List<GameResultCommentResponse> list = jpaQueryFactory
                 .selectDistinct(Projections.constructor(
                         GameResultCommentResponse.class,
@@ -93,7 +93,8 @@ public class GameResultCommentRepositoryImpl implements GameResultCommentReposit
                         comments.updatedDate.as("updatedDateTime"),
                         comments.likes.size().as("like"),
                         this.isLikedExpression(users).as("existsLiked"),
-                        comments.users.uid.eq(gameUser.uid).as("existsWriter")
+                        comments.users.uid.eq(gameUser.uid).as("existsWriter"),
+                        existsMineCondition.as("existsMine")
                 ))
                 .from(comments)
                 .leftJoin(comments.users, user)

--- a/src/main/java/com/games/balancegameback/infra/repository/game/impl/GameResultCommentRepositoryImpl.java
+++ b/src/main/java/com/games/balancegameback/infra/repository/game/impl/GameResultCommentRepositoryImpl.java
@@ -70,9 +70,11 @@ public class GameResultCommentRepositoryImpl implements GameResultCommentReposit
         // 비로그인 회원은 좋아요를 표시했는지 안했는지 모르기 때문에 조건 추가.
         BooleanExpression leftJoinCondition = users != null ? comments.users.uid.eq(users.getUid()) : Expressions.FALSE;
 
-        String userUid = users != null ? users.getUid() : "";
-        Expression<Boolean> existsMineExpression = Expressions.booleanTemplate("{0} COLLATE utf8mb4_general_ci = {1} COLLATE utf8mb4_general_ci",
-                comments.users.uid, userUid);
+        // existsMine 비교 조건 - 문자열 길이를 활용한 안전한 비교 방식
+        Expression<Boolean> existsMineExpression = users != null
+                ? Expressions.booleanTemplate("char_length({0}) = char_length({1}) and {0} = {1}",
+                    comments.users.uid, Expressions.constant(users.getUid()))
+                    : Expressions.FALSE;
 
         OrderSpecifier<?> orderSpecifier = this.getOrderSpecifier(searchRequest.getSortType());
 

--- a/src/main/java/com/games/balancegameback/infra/repository/game/impl/GameResultCommentRepositoryImpl.java
+++ b/src/main/java/com/games/balancegameback/infra/repository/game/impl/GameResultCommentRepositoryImpl.java
@@ -93,8 +93,9 @@ public class GameResultCommentRepositoryImpl implements GameResultCommentReposit
                         comments.likes.size().as("like"),
                         this.isLikedExpression(users).as("existsLiked"),
                         comments.users.uid.eq(gameUser.uid).as("existsWriter"),
-                        Expressions.booleanTemplate("{0} = {1}", comments.users.uid,
-                                users != null ? users.getUid() : "")
+                        Expressions.booleanTemplate("binary {0} = binary {1}",
+                                comments.users.uid, users != null ? users.getUid() : "")
+
                 ))
                 .from(comments)
                 .leftJoin(comments.users, user)

--- a/src/main/java/com/games/balancegameback/infra/repository/user/UserJpaRepository.java
+++ b/src/main/java/com/games/balancegameback/infra/repository/user/UserJpaRepository.java
@@ -14,4 +14,6 @@ public interface UserJpaRepository extends JpaRepository<UsersEntity, String> {
     boolean existsByEmailAndIsDeleted(String email, boolean deleted);
 
     boolean existsByNickname(String nickname);
+
+    boolean existsByUid(String uid);
 }

--- a/src/main/java/com/games/balancegameback/service/game/GameService.java
+++ b/src/main/java/com/games/balancegameback/service/game/GameService.java
@@ -240,7 +240,7 @@ public class GameService {
     private void validateRequest(Long roomId, HttpServletRequest request) {
         Users users = userUtils.findUserByToken(request);
 
-        if (!gameRepository.existsIdAndUsersEmail(roomId, users.getEmail())) {
+        if (!gameRepository.existsIdAndUsers(roomId, users)) {
             throw new UnAuthorizedException("정보가 일치하지 않습니다.", ErrorCode.ACCESS_DENIED_EXCEPTION);
         }
     }

--- a/src/main/java/com/games/balancegameback/service/game/GameService.java
+++ b/src/main/java/com/games/balancegameback/service/game/GameService.java
@@ -55,8 +55,8 @@ public class GameService {
     }
 
     // 게임 설정값 반환
-    public GameDetailResponse getGameStatus(Long gameId) {
-        return gameListService.getGameStatus(gameId);
+    public GameDetailResponse getGameStatus(Long gameId, HttpServletRequest request) {
+        return gameListService.getGameStatus(gameId, request);
     }
 
     // 게임방 생성

--- a/src/main/java/com/games/balancegameback/service/game/impl/GameListService.java
+++ b/src/main/java/com/games/balancegameback/service/game/impl/GameListService.java
@@ -1,8 +1,11 @@
 package com.games.balancegameback.service.game.impl;
 
 import com.games.balancegameback.core.utils.CustomPageImpl;
+import com.games.balancegameback.domain.user.Users;
 import com.games.balancegameback.dto.game.*;
 import com.games.balancegameback.service.game.repository.GameListRepository;
+import com.games.balancegameback.service.user.impl.UserUtils;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -12,6 +15,7 @@ import org.springframework.stereotype.Service;
 public class GameListService {
 
     private final GameListRepository gameListRepository;
+    private final UserUtils userUtils;
 
     public CustomPageImpl<GameListResponse> getMainGameList(Long cursorId, Pageable pageable,
                                                             GameSearchRequest searchRequest) {
@@ -22,7 +26,8 @@ public class GameListService {
         return gameListRepository.getCategoryCounts(title);
     }
 
-    public GameDetailResponse getGameStatus(Long gameId) {
-        return gameListRepository.getGameStatus(gameId);
+    public GameDetailResponse getGameStatus(Long gameId, HttpServletRequest request) {
+        Users users = userUtils.findUserByToken(request);
+        return gameListRepository.getGameStatus(gameId, users);
     }
 }

--- a/src/main/java/com/games/balancegameback/service/game/impl/GameRoomService.java
+++ b/src/main/java/com/games/balancegameback/service/game/impl/GameRoomService.java
@@ -98,7 +98,7 @@ public class GameRoomService {
     }
 
     private void existsHost(Long gameId, Users users) {
-        if (gameRepository.existsIdAndUsersEmail(gameId, users.getEmail())) {
+        if (!gameRepository.existsIdAndUsersEmail(gameId, users.getEmail())) {
             throw new UnAuthorizedException("게임 주인이 아닙니다.", ErrorCode.NOT_ALLOW_WRITE_EXCEPTION);
         }
     }

--- a/src/main/java/com/games/balancegameback/service/game/impl/GameRoomService.java
+++ b/src/main/java/com/games/balancegameback/service/game/impl/GameRoomService.java
@@ -98,7 +98,7 @@ public class GameRoomService {
     }
 
     private void existsHost(Long gameId, Users users) {
-        if (!gameRepository.existsIdAndUsersEmail(gameId, users.getEmail())) {
+        if (!gameRepository.existsIdAndUsers(gameId, users)) {
             throw new UnAuthorizedException("게임 주인이 아닙니다.", ErrorCode.NOT_ALLOW_WRITE_EXCEPTION);
         }
     }

--- a/src/main/java/com/games/balancegameback/service/game/impl/comment/GameResourceCommentService.java
+++ b/src/main/java/com/games/balancegameback/service/game/impl/comment/GameResourceCommentService.java
@@ -2,6 +2,7 @@ package com.games.balancegameback.service.game.impl.comment;
 
 import com.games.balancegameback.core.exception.ErrorCode;
 import com.games.balancegameback.core.exception.impl.BadRequestException;
+import com.games.balancegameback.core.exception.impl.NotFoundException;
 import com.games.balancegameback.core.exception.impl.UnAuthorizedException;
 import com.games.balancegameback.core.utils.CustomPageImpl;
 import com.games.balancegameback.domain.game.GameResourceComments;
@@ -48,11 +49,7 @@ public class GameResourceCommentService {
                            HttpServletRequest request) {
 
         if (!commentsRepository.existsByGameIdAndResourceId(gameId, resourceId)) {
-            throw new BadRequestException("해당 리소스는 존재하지 않습니다.", ErrorCode.NOT_FOUND_EXCEPTION);
-        }
-
-        if (!commentsRepository.existsById(commentRequest.getParentId())) {
-            throw new BadRequestException("해당 댓글은 존재하지 않습니다.", ErrorCode.NOT_FOUND_EXCEPTION);
+            throw new NotFoundException("해당 리소스는 존재하지 않습니다.", ErrorCode.NOT_FOUND_EXCEPTION);
         }
 
         if (commentRequest.getParentId() != null && commentsRepository.isChildComment(commentRequest.getParentId())) {

--- a/src/main/java/com/games/balancegameback/service/game/repository/GameListRepository.java
+++ b/src/main/java/com/games/balancegameback/service/game/repository/GameListRepository.java
@@ -1,6 +1,7 @@
 package com.games.balancegameback.service.game.repository;
 
 import com.games.balancegameback.core.utils.CustomPageImpl;
+import com.games.balancegameback.domain.user.Users;
 import com.games.balancegameback.dto.game.GameCategoryNumsResponse;
 import com.games.balancegameback.dto.game.GameDetailResponse;
 import com.games.balancegameback.dto.game.GameListResponse;
@@ -13,5 +14,5 @@ public interface GameListRepository {
 
     GameCategoryNumsResponse getCategoryCounts(String title);
 
-    GameDetailResponse getGameStatus(Long gameId);
+    GameDetailResponse getGameStatus(Long gameId, Users users);
 }

--- a/src/main/java/com/games/balancegameback/service/game/repository/GameRepository.java
+++ b/src/main/java/com/games/balancegameback/service/game/repository/GameRepository.java
@@ -18,7 +18,7 @@ public interface GameRepository {
 
     CustomPageImpl<GameListResponse> findGamesWithResources(Long cursorId, Users users, Pageable pageable, GameSearchRequest searchRequest);
 
-    boolean existsIdAndUsersEmail(Long gameId, String email);
+    boolean existsIdAndUsers(Long gameId, Users users);
 
     boolean existsGameRounds(Long gameId, int roundNumber);
 

--- a/src/main/java/com/games/balancegameback/service/game/repository/GameResourceCommentRepository.java
+++ b/src/main/java/com/games/balancegameback/service/game/repository/GameResourceCommentRepository.java
@@ -27,10 +27,6 @@ public interface GameResourceCommentRepository {
                                                                                            Users users, Pageable pageable,
                                                                                            GameCommentSearchRequest request);
 
-    boolean existsByGameIdAndResourceIdAndCommentId(Long gameId, Long resourceId, Long commentId);
-
-    boolean existsById(Long commentId);
-
     boolean isChildComment(Long parentId);
 
     boolean existsByGameIdAndResourceId(Long gameId, Long resourceId);

--- a/src/main/java/com/games/balancegameback/service/media/MediaService.java
+++ b/src/main/java/com/games/balancegameback/service/media/MediaService.java
@@ -58,7 +58,7 @@ public class MediaService {
             throw new UnAuthorizedException("유효하지 않은 사용자입니다.", ErrorCode.ACCESS_DENIED_EXCEPTION);
         }
 
-        if (gameRepository.existsIdAndUsersEmail(gameId, users.getEmail())) {
+        if (!gameRepository.existsIdAndUsersEmail(gameId, users.getEmail())) {
             throw new UnAuthorizedException("정보가 일치하지 않습니다.", ErrorCode.ACCESS_DENIED_EXCEPTION);
         }
     }

--- a/src/main/java/com/games/balancegameback/service/media/MediaService.java
+++ b/src/main/java/com/games/balancegameback/service/media/MediaService.java
@@ -58,7 +58,7 @@ public class MediaService {
             throw new UnAuthorizedException("유효하지 않은 사용자입니다.", ErrorCode.ACCESS_DENIED_EXCEPTION);
         }
 
-        if (!gameRepository.existsIdAndUsersEmail(gameId, users.getEmail())) {
+        if (!gameRepository.existsIdAndUsers(gameId, users)) {
             throw new UnAuthorizedException("정보가 일치하지 않습니다.", ErrorCode.ACCESS_DENIED_EXCEPTION);
         }
     }

--- a/src/main/java/com/games/balancegameback/web/game/GameListController.java
+++ b/src/main/java/com/games/balancegameback/web/game/GameListController.java
@@ -10,7 +10,9 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -65,9 +67,11 @@ public class GameListController {
     @GetMapping(value = "/{gameId}")
     public GameDetailResponse getGameStatus(
             @Parameter(name = "gameId", description = "게임방의 ID", required = true)
-            @PathVariable(name = "gameId") Long gameId) {
+            @PathVariable(name = "gameId") Long gameId,
 
-        return gameService.getGameStatus(gameId);
+            HttpServletRequest request) {
+
+        return gameService.getGameStatus(gameId, request);
     }
 
     @Operation(summary = "각 카테고리 별 게임 갯수 출력 API", description = "각 카테고리 별 게임 갯수를 출력한다.")

--- a/src/main/java/com/games/balancegameback/web/game/GameResourceCommentController.java
+++ b/src/main/java/com/games/balancegameback/web/game/GameResourceCommentController.java
@@ -14,7 +14,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -81,8 +81,8 @@ cloud:
 
 jwt:
   secret: ENC(RnxzhwA89XJzO4TUyxgV/PnW76a1js2bl3fUmHhFqlZjo0EpTx9EQeKyoNZ0LyirrFWRz2jXx/886s2MOnvDx4TFsQs5pYHTfPYJYV3wLjE34NwIzrE6DWnRnQ26b0ueI3jw6tYO8vW1al9KcyhavMkjAQ1PhcTH0gNQD0imFXruxxT2qYxtbR/CT7ErOZ+2lrevEDutMZG/2zez66W9mDrUNYdQ6Zwdij8J4CvrcgtVhteUZFIz6eVJb72SnPap1/yxD6rmEzMB/pjNqNN/m14xODPTbrHnqOFAS+c/TZ0=)
-  accessTokenExpiration: ENC(3SILZhqKsTa28bgYIYu8Lg==)
-  refreshTokenExpiration: ENC(2Ily8VmFFYVxg19u2omwH7m6kx/InJ+7)
+  accessTokenExpiration: 86400000
+  refreshTokenExpiration: 604800000
 
 #management:
 #  endpoints:


### PR DESCRIPTION
## 작업내용 설명
- 대댓글을 연속으로 달시 에러가 발생하는 쿼리를 수정함.
- 존재하지 않는 id 를 parentId 로 넣었을 시 404 에러 반환하도록 수정함.
- 위 버그들을 고치면서 RESTful 하지 못한 API 들을 리팩토링 진행함.
- 페이징 처리의 hasNext 부분에서 경계값을 만났을 때 제대로 처리하지 못하는 버그 수정함.
- 댓글, 게임 목록 등에서 내가 만든 것인지 식별할 수 있는 boolean 타입 추가
  - 비로그인 유저에게는 무조건 false 가 반환되며, 로그인 한 내 정보와 일치해야 true 반환하도록 설계함.

## 관련 이슈
- https://github.com/Rookeys/balance-game-back/issues/68
- https://github.com/Rookeys/balance-game-back/issues/71

## PR 유형
- [x] 버그 수정
- [ ] 새로운 기능 추가
- [ ] 사용자 UI 디자인 변경
- [x] 코드 리팩토링
- [ ] 테스트 추가
- [ ] 기타 (내용을 적어주세요) :

## PR 체크리스트
- [x] 로컬 빌드가 정상적으로 실행되었습니다.
- [x] PR 작업에 대한 테스트를 완료하였습니다.