### PR TITLE
chore: 게임 검색에서 리소스 제목 제외.

### DIFF
--- a/src/main/java/com/games/balancegameback/infra/repository/game/strategy/AbstractGameListStrategy.java
+++ b/src/main/java/com/games/balancegameback/infra/repository/game/strategy/AbstractGameListStrategy.java
@@ -43,18 +43,13 @@ public abstract class AbstractGameListStrategy implements GameListStrategy {
         return GameQClasses.category.category.eq(category);
     }
     
-    /**
-     * 제목 검색 조건 생성
-     * 게임 제목, 리소스 제목, 작성자 닉네임에서 검색
-     */
     protected BooleanExpression buildTitleSearchCondition(String title) {
         if (!StringUtils.hasText(title)) {
             return null;
         }
-        
+
         String searchTitle = title.trim();
         return GameQClasses.games.title.containsIgnoreCase(searchTitle)
-                .or(GameQClasses.resources.title.containsIgnoreCase(searchTitle))
                 .or(GameQClasses.users.nickname.containsIgnoreCase(searchTitle)
                         .and(GameQClasses.games.isNamePrivate.eq(false)));
     }


### PR DESCRIPTION
## 작업내용 설명
- 메인 페이지 게임 검색에서 리소스 제목 필터 제거.

## PR 유형
- [x] 버그 수정
- [ ] 새로운 기능 추가
- [ ] 사용자 UI 디자인 변경
- [ ] 코드 리팩토링
- [ ] 테스트 추가
- [ ] 기타 (내용을 적어주세요) :

## PR 체크리스트
- [x] 로컬 빌드가 정상적으로 실행되었습니다.
- [x] PR 작업에 대한 테스트를 완료하였습니다.